### PR TITLE
Replace mock preconditions with fact checking function

### DIFF
--- a/test/flint-example-awb.json
+++ b/test/flint-example-awb.json
@@ -184,6 +184,15 @@
     },
     {
       "explanation": "",
+      "fact": "[wetgevende macht]",
+      "function": "[]",
+      "reference": "",
+      "version": "",
+      "juriconnect": "",
+      "sourcetext": "Added, because it was missing in excel"
+    },
+    {
+      "explanation": "",
       "fact": "[besluit]",
       "function": "[schriftelijke beslissing van een bestuursorgaan]\r\nEN\r\n[beslissing inhoudende een publiekrechtelijke rechtshandeling]",
       "reference": "art. 1:3 lid 1 Awb",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -458,7 +458,9 @@ describe('discipl-law-reg', () => {
 
       let modelLink = await lawReg.publish(lawmakerSsid, { ...awb, 'model': 'AWB' }, {
         '[persoon wiens belang rechtstreeks bij een besluit is betrokken]':
-          'IS:' + belanghebbendeSsid.did
+          'IS:' + belanghebbendeSsid.did,
+        '[wetgevende macht]':
+          'IS:' + bestuursorgaanSsid.did
       })
 
       let retrievedModel = await core.get(modelLink)
@@ -488,9 +490,8 @@ describe('discipl-law-reg', () => {
         if (typeof fact === 'string') {
           // interested party
           return fact === '[persoon wiens belang rechtstreeks bij een besluit is betrokken]' ||
-            fact === '[aanvraag is geheel of gedeeltelijk geweigerd op grond van artikel 2:15 Awb]' ||
-            // temporary shortcut
-            fact === '[wetgevende macht]'
+            // preconditions
+            fact === '[aanvraag is geheel of gedeeltelijk geweigerd op grond van artikel 2:15 Awb]'
         }
         return false
       }


### PR DESCRIPTION
This PR replaces the "checkPreconditions", which was just a mock, with a call to the actual preconditions function.

In implementing this, I ran into the issue that the whole structure got kind-of spaghettish, because of the different ways we can check facts, and the slightly different patterns that occur.

I propose that in the near future we take a small step back and refactor this to a simpler structure. I've taken the liberty to create #16 for this. I'm also very open to suggestions how we can simplify it already in this PR.

This PR fixes #15 