### PR TITLE
Introducing trinary logic to determine potentially possible acts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/law-reg",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Discipl Law and Regulation Compliance Library",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/index.js
+++ b/src/index.js
@@ -397,10 +397,11 @@ _ "whitespace"
    *
    * @param {string} caseLink - Link to the case, last action that was taken
    * @param {object} ssid - Identifies the actor
-   * @param {ActionInformation[]} facts - Array of true facts
+   * @param {string[]} facts - Array of true facts
+   * @param {string[]} nonFacts - Array of false facts
    * @returns {Promise<Array>}
    */
-  async getAvailableActs (caseLink, ssid, facts) {
+  async getAvailableActs (caseLink, ssid, facts = [], nonFacts = []) {
     const core = this.abundance.getCoreAPI()
 
     const firstCaseLink = await this._getFirstCaseLink(caseLink, ssid)
@@ -411,7 +412,16 @@ _ "whitespace"
     const acts = await model.data[DISCIPL_FLINT_MODEL].acts
 
     const factResolver = (fact) => {
-      return facts.includes(fact)
+      if (facts.includes(fact)) {
+        return true
+      }
+
+      if (nonFacts.includes(fact)) {
+        return false
+      }
+
+      logger.info('Assuming fact', fact, 'to be false by default in getAvailableActs')
+      return false
     }
 
     const allowedActs = []
@@ -441,10 +451,11 @@ _ "whitespace"
    *
    * @param {string} caseLink - Link to the case, last action that was taken
    * @param {object} ssid - Identifies the actor
-   * @param {ActionInformation[]} facts - Array of true facts
+   * @param {string[]} facts - Array of true facts
+   * @param {string[]} nonFacts - Array of false facts
    * @returns {Promise<Array>}
    */
-  async getPotentialActs (caseLink, ssid, facts) {
+  async getPotentialActs (caseLink, ssid, facts = [], nonFacts = []) {
     const core = this.abundance.getCoreAPI()
 
     const firstCaseLink = await this._getFirstCaseLink(caseLink, ssid)
@@ -462,6 +473,11 @@ _ "whitespace"
         if (facts.includes(fact)) {
           return true
         }
+
+        if (nonFacts.includes(fact)) {
+          return false
+        }
+
         logger.debug('Missing fact', fact, 'during checking of act', Object.keys(actWithLink)[0])
 
         if (!unknownItems.includes(flintItem)) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,7 +6,7 @@ import * as log from 'loglevel'
 import awb from './flint-example-awb'
 
 // Adjusting log level for debugging can be done here, or in specific tests that need more finegrained logging during development
-log.getLogger('disciplLawReg').setLevel('warn')
+log.getLogger('disciplLawReg').setLevel('debug')
 
 const lawReg = new LawReg()
 
@@ -59,6 +59,31 @@ describe('discipl-law-reg', () => {
       let result = await lawReg.checkExpression(parsedFact, ssid, { 'factResolver': factResolver })
 
       expect(result).to.equal(true)
+
+      expect(parsedFact).to.deep.equal({
+        'expression': 'AND',
+        'operands': [
+          '[fact1]',
+          '[fact2]',
+          '[fact3]'
+        ]
+      })
+    })
+
+    it('correctly parses a multiple AND construction with undefined', async () => {
+      let parsedFact = lawReg.factParser.parse('[fact1] EN [fact2] EN [fact3]')
+      let core = lawReg.getAbundanceService().getCoreAPI()
+      let ssid = await core.newSsid('ephemeral')
+
+      const factResolver = (fact) => {
+        if (fact === '[fact1]' || fact === '[fact2]') {
+          return true
+        }
+      }
+      let result = await lawReg.checkExpression(parsedFact, ssid, { 'factResolver': factResolver })
+
+      // eslint-disable-next-line no-unused-expressions
+      expect(result).to.be.undefined
 
       expect(parsedFact).to.deep.equal({
         'expression': 'AND',

--- a/test/lerarenbeurs-scenarios.spec.js
+++ b/test/lerarenbeurs-scenarios.spec.js
@@ -119,6 +119,24 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
     expect(allowedActNames).to.deep.equal(['<<indienen verzoek een besluit te nemen>>'])
   }).timeout(10000)
 
+  it('should be able to determine available actions with nonfacts', async () => {
+    let needSsid = await core.newSsid('ephemeral')
+
+    await core.allow(needSsid)
+    let needLink = await core.claim(needSsid, {
+      'need': {
+        'act': '<<indienen verzoek een besluit te nemen>>',
+        'DISCIPL_FLINT_MODEL_LINK': modelLink
+      }
+    })
+
+    let allowedActs = await lawReg.getAvailableActs(needLink, ssids['belanghebbende'], [], ['[verzoek een besluit te nemen]'])
+
+    let allowedActNames = allowedActs.map((act) => act.act)
+
+    expect(allowedActNames).to.deep.equal([])
+  }).timeout(10000)
+
   it('should be able to determine potentially available actions', async () => {
     let { ssids, modelLink } = await setupModel()
 
@@ -138,6 +156,30 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(allowedActNames).to.deep.equal([
       '<<indienen verzoek een besluit te nemen>>',
+      '<<leraar vraagt subsidie voor studiekosten aan>>',
+      '<<leraar vraagt subsidie voor studieverlof voor het bevoegd gezag>>',
+      '<<inleveren of verzenden ingevuld aanvraagformulier lerarenbeurs>>'
+    ])
+  }).timeout(10000)
+
+  it('should be able to determine potentially available actions with non-facts', async () => {
+    let { ssids, modelLink } = await setupModel()
+
+    let needSsid = await core.newSsid('ephemeral')
+
+    await core.allow(needSsid)
+    let needLink = await core.claim(needSsid, {
+      'need': {
+        'act': '<<indienen verzoek een besluit te nemen>>',
+        'DISCIPL_FLINT_MODEL_LINK': modelLink
+      }
+    })
+
+    let allowedActs = await lawReg.getPotentialActs(needLink, ssids['belanghebbende'], [], ['[verzoek een besluit te nemen]'])
+
+    let allowedActNames = allowedActs.map((act) => act.act)
+
+    expect(allowedActNames).to.deep.equal([
       '<<leraar vraagt subsidie voor studiekosten aan>>',
       '<<leraar vraagt subsidie voor studieverlof voor het bevoegd gezag>>',
       '<<inleveren of verzenden ingevuld aanvraagformulier lerarenbeurs>>'


### PR DESCRIPTION
This PR supersedes #42. This closes #43 and closes #39 

We return undefined to signal we don't know a particular fact. The logic processing has been extended to check for undefined items. It still short-circuits in the same way if it knows for sure that expressions cannot change the results. The resulting acts that are potentially available stayed the same. This is to be expected, as we ordered some of the preconditions to short-circuit in the right way. Now, for these expressions, the order of operands no longer matters.