### PR TITLE
Introduce the CREATE expression in favour of <<>>

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -10,6 +10,12 @@
       }
     ]
   ],
+  "env": {
+    "development": {
+      "sourceMaps": "inline",
+      "retainLines": true
+    }
+  },
   "plugins": [
     "babel-plugin-dynamic-import-node"
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,29 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "launch",
+            "name": "Mocha Tests",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
+            "args": [
+                "${workspaceFolder}/test",
+                "--require",
+                "@babel/register",
+                "-u",
+                "bdd",
+                "--timeout",
+                "10",
+                "--colors"
+            ],
+            "internalConsoleOptions": "openOnSessionStart",
+            "skipFiles": [
+                "<node_internals>/**"
+            ],
+            "sourceMaps": true
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "/dist"
   ],
   "scripts": {
-    "prepack": "babel src/ --out-dir dist",
+    "prepack": "NODE_ENV=production babel src/ --out-dir dist",
     "test": "nyc --reporter=html --reporter=text ./node_modules/.bin/mocha --require @babel/register ./test/**/*.spec.js --timeout 10s",
     "lint": "./node_modules/standard/bin/cmd.js --parser babel-eslint",
     "lint-fix": "./node_modules/standard/bin/cmd.js --parser babel-eslint --fix",

--- a/src/index.js
+++ b/src/index.js
@@ -481,30 +481,29 @@ class LawReg {
   async checkCreatedFact (fact, ssid, context) {
     logger.debug('Checking if', fact, 'was created')
     const core = this.abundance.getCoreAPI()
-    let actionLink = context.caseLink
+    let caseLink = context.caseLink
 
     const possibleCreatingActions = []
     const terminatedCreatingActions = []
 
-    while (actionLink != null) {
-      const lastAction = await core.get(actionLink, ssid)
+    while (caseLink != null) {
+      const caseData = await core.get(caseLink, ssid)
+      const lastTakenAction = caseData.data[DISCIPL_FLINT_ACT_TAKEN]
 
-      const actLink = lastAction.data[DISCIPL_FLINT_ACT_TAKEN]
-
-      if (actLink != null) {
-        const act = await core.get(actLink, ssid)
+      if (lastTakenAction != null) {
+        const act = await core.get(lastTakenAction, ssid)
         logger.debug('Found earlier act', act)
 
         if (act.data[DISCIPL_FLINT_ACT].create != null && act.data[DISCIPL_FLINT_ACT].create.includes(fact)) {
-          possibleCreatingActions.push(actionLink)
+          possibleCreatingActions.push(caseLink)
         }
 
         if (act.data[DISCIPL_FLINT_ACT].terminate != null && act.data[DISCIPL_FLINT_ACT].terminate.includes(fact)) {
-          const terminatedLink = lastAction.data[DISCIPL_FLINT_FACTS_SUPPLIED][fact]
+          const terminatedLink = caseData.data[DISCIPL_FLINT_FACTS_SUPPLIED][fact]
           terminatedCreatingActions.push(terminatedLink)
         }
       }
-      actionLink = lastAction.data[DISCIPL_FLINT_PREVIOUS_CASE]
+      caseLink = caseData.data[DISCIPL_FLINT_PREVIOUS_CASE]
     }
 
     const creatingActions = possibleCreatingActions.filter((maybeTerminatedLink) => !terminatedCreatingActions.includes(maybeTerminatedLink))

--- a/src/index.js
+++ b/src/index.js
@@ -40,7 +40,7 @@ class LawReg {
   /**
    * Checks a parsed expression by considering the atomic parts and evaluating them
    *
-   * @param {ParsedExpression|string} fact - Parsed fact object (might be string if the object is an atomic fact
+   * @param {ParsedExpression|string} fact - Parsed fact object (might be string if the object is an atomic fact)
    * @param {object} ssid - Identity doing the checking
    * @param {Context} context - Context of the check
    * @returns {Promise<boolean>}
@@ -286,6 +286,13 @@ class LawReg {
 
         this._extendContextExplanationWithResult(context, literalValue)
         return literalValue
+      case 'CREATE':
+        logger.debug('Swithc case: CREATE')
+        const finalCreateResult = await this.checkCreatedFact(context.previousFact, ssid, context)
+        logger.debug('Resolving fact', fact, 'as', finalCreateResult, 'by determining earlier creation')
+        this._extendContextExplanationWithResult(context, finalCreateResult)
+
+        return finalCreateResult
       default:
         logger.debug('Switch case: default')
         if (typeof fact === 'string') {
@@ -345,13 +352,6 @@ class LawReg {
     const core = this.abundance.getCoreAPI()
     const factReference = await core.get(factLink, ssid)
     const functionRef = factReference.data[DISCIPL_FLINT_FACT].function
-
-    if (functionRef === '<<>>') {
-      const factIsCreated = await this.checkCreatedFact(fact, ssid, context)
-      logger.debug('Resolving fact', fact, 'as', factIsCreated, 'by determining earlier creation')
-      this._extendContextExplanationWithResult(context, factIsCreated)
-      return factIsCreated
-    }
 
     if (functionRef === DISCIPL_ANYONE_MARKER) {
       logger.debug('Resolving fact', fact, 'as true, because anyone can be this')
@@ -446,14 +446,14 @@ class LawReg {
   }
 
   /**
-   * Checks a fact by using the callback provided as factResolver
+   * Checks a fact by using the factResolver from the context.
    * If an empty fact is to be checked, this is because a reference was followed. in this case we fall back
    * to the previousFact, which likely contains information that can be used to resolve this.
    *
    * @param {string} fact - Description of the fact, surrounded with []
    * @param {object} ssid - Identity of entity doing the checking
    * @param {Context} context - context of the checking
-   * @returns {boolean}
+   * @returns {Promise<boolean>}
    */
   async checkFactWithResolver (fact, ssid, context) {
     const factToCheck = fact === '[]' || fact === '' ? context.previousFact : fact
@@ -476,7 +476,7 @@ class LawReg {
    * @param {string} fact - Description of the fact, surrounded with []
    * @param {object} ssid - Identity of entity doing the checking
    * @param {Context} context - context of the checking
-   * @returns {boolean}
+   * @returns {Promise<boolean>}
    */
   async checkCreatedFact (fact, ssid, context) {
     logger.debug('Checking if', fact, 'was created')
@@ -879,6 +879,11 @@ class LawReg {
    * in the channel of the given ssid. Each act, fact and duty is stored in a separate vc.
    * Returns a list to the claim holding the whole model with links to individual claims
    * Note that references within the model are not translated into links.
+   *
+   * @param {object} ssid SSID that publishes the model
+   * @param {object} flintModel Model to publish
+   * @param {object} factFunctions Additional factFunction that are declared outside the model
+   * @return {Promise<string>} Link to a verifiable claim that holds the published model
    */
   async publish (ssid, flintModel, factFunctions = {}) {
     logger.debug('Publishing model')
@@ -950,7 +955,7 @@ class LawReg {
    * @param {string} caseLink - Link to the case, which is either an earlier action, or a need
    * @param {string} act - description of the act to be taken
    * @param {function} factResolver - Function used to resolve facts to fall back on if no other method is available. Defaults to always false
-   * @returns {Promise<*>}
+   * @returns {Promise<string>} Link to a verifiable claim that holds that taken actions
    */
   async take (ssid, caseLink, act, factResolver = () => false) {
     const { core, modelLink, actLink, firstCaseLink } = await this._getModelAndActFromCase(caseLink, ssid, act)
@@ -973,13 +978,13 @@ class LawReg {
   }
 
   /**
-   * Denotes a given act in the context of a case as taken, if it is possible. See {@link checkAction} is used to check the conditions
+   * Add the result of an action to the explanation part of the context. {@link checkAction} is used to check the conditions.
    *
    * @param {object} ssid - Identity of the actor
    * @param {string} caseLink - Link to the case, which is either an earlier action, or a need
-   * @param {string} act - description of the act to be taken
+   * @param {string} act - description of the act to explain
    * @param {function} factResolver - Function used to resolve facts to fall back on if no other method is available. Defaults to always false
-   * @returns {Promise<*>}
+   * @returns {Promise<object>} Explanation object from the context with the action result as value
    */
   async explain (ssid, caseLink, act, factResolver) {
     const { modelLink, actLink } = await this._getModelAndActFromCase(caseLink, ssid, act)
@@ -1008,10 +1013,12 @@ class LawReg {
   }
 
   /**
+   * Create a default resolver and extend it's logic with additional facts and a fallback resolver. The fallback is used
+   * when no other methods are available to resolve the supplied facts.
    *
    * @param {function} factResolver - Function used to resolve facts to fall back on if no other method is available
    * @param {Object} factsSupplied - Facts object
-   * @return {function} factResolver - Function used to resolve facts to fall back on if no other method is available
+   * @return {function} Function used to resolve facts to fall back on if no other method is available
    * @private
    */
   _wrapWithDefault (factResolver, factsSupplied) {

--- a/src/modelValidator.js
+++ b/src/modelValidator.js
@@ -313,7 +313,7 @@ class ModelValidator {
 
     const veryStrict = []
     const lessStrict = ['']
-    const factStrict = ['<<>>', '[]']
+    const factStrict = ['[]']
     const expressionCheckInfo = [['acts', 'actor', veryStrict], ['acts', 'object', veryStrict], ['acts', 'recipient', veryStrict],
       ['acts', 'preconditions', lessStrict], ['facts', 'function', factStrict]]
 

--- a/test/flint-example-awb.json
+++ b/test/flint-example-awb.json
@@ -361,7 +361,7 @@
     {
       "explanation": "",
       "fact": "[aanvraag]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "reference": "art. 1:3 lid 1 en 3 Awb",
       "version": "2-[19980101]-[jjjjmmdd]",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",

--- a/test/flint-example-lerarenbeurs.json
+++ b/test/flint-example-lerarenbeurs.json
@@ -959,7 +959,7 @@
     },
     {
       "fact": "[besluit]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "2-[19980101]-[jjjjmmdd]",
       "art": "art. 1:3 lid 1 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=1&z=2017-03-01&g=2017-03-01",
@@ -1076,7 +1076,7 @@
     },
     {
       "fact": "[aanvraag]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "2-[19980101]-[jjjjmmdd]",
       "art": "art. 1:3 lid 1 en 3 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",
@@ -1094,7 +1094,7 @@
     },
     {
       "fact": "[aanvraag subsidieverlening]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 4:35 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35",
@@ -1103,7 +1103,7 @@
     },
     {
       "fact": "[aanvraag subsidie voor studiekosten]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 7 lid 1 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=1",
@@ -1112,7 +1112,7 @@
     },
     {
       "fact": "[aanvraag subsidie voor studieverlof]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 8 lid 1 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=1",
@@ -1121,7 +1121,7 @@
     },
     {
       "fact": "[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 7 lid 2 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=2",
@@ -1148,7 +1148,7 @@
     },
     {
       "fact": "[aanvraagformulieren studieverlof op de website van de Dienst Uitvoering Onderwijs]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 8 lid 2 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=2",
@@ -1175,7 +1175,7 @@
     },
     {
       "fact": "[subsidieontvanger studiekosten]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 3 lid 1 onder a Sbl",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
@@ -1193,7 +1193,7 @@
     },
     {
       "fact": "[formulier voor het indienen van aanvragen en het verstrekken van gegevens is vastgesteld door bestuursorgaan]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "2-[19940101]-[jjjjmmdd]",
       "art": "art. 4:4 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4&z=2017-03-01&g=2017-03-01",
@@ -2794,7 +2794,7 @@
     },
     {
       "fact": "[besluit tot verlenen subsidie voor kosten in verband met het verlenen van studieverlof aan de leraar]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art.3 lid 1, onder b Slb",
       "juriconnect": "",
@@ -2803,7 +2803,7 @@
     },
     {
       "fact": "[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 4:23, lid 1 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.1&artikel=4:23&lid=1",
@@ -2812,7 +2812,7 @@
     },
     {
       "fact": "[verzoek tot bewijs van het behalen van ten minste vijftien studiepunten]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "Art. 19, onder b Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
@@ -2830,7 +2830,7 @@
     },
     {
       "fact": "[verzoek tot bewijs van betaling van collegegeld]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "Art. 19, onder a Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
@@ -2873,7 +2873,7 @@
     },
     {
       "fact": "[leraar heeft minder dan 15 studiepunten gehaald]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "Art. 13, lid 1  Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
@@ -2882,7 +2882,7 @@
     },
     {
       "fact": "[leraar heeft binnen 2 maanden na verstrekking van de subsidie de aanvraag voor subsidie ingetrokken]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "Art. 13, lid 2, aanhef en omnder a  Slb",
       "juriconnect": "3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
@@ -2960,7 +2960,7 @@
     },
     {
       "fact": "[subsidieontvanger]",
-      "function": "<<>>",
+      "function": { "expression": "CREATE" },
       "version": "",
       "art": "art. 5.7 lid 1, aanhef en onder b. Kaderregeling subsidies OCW, SZW en VWS",
       "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -898,6 +898,65 @@ describe('discipl-law-reg', () => {
       expect(errorMessage).to.equal('Unknown expression type')
     })
 
+    it('should reject an action when a fact defined with a "CREATE" epxression is supplied', async () => {
+      const core = lawReg.getAbundanceService().getCoreAPI()
+      const util = new Util(lawReg)
+      const { ssids, modelLink } = await util.setupModel({
+        'model': 'Fictieve kinderbijslag',
+        'acts': [
+          {
+            'act': '<<kinderbijslag aanvragen>>',
+            'actor': '[ouder]',
+            'object': '[verzoek]',
+            'recipient': '[Minister]',
+            'create': []
+          },
+          {
+            'act': '<<aanvraag kinderbijslag toekennen>>',
+            'actor': '[Minister]',
+            'object': '[aanvraag]',
+            'recipient': '[ouder]',
+            'preconditions': {
+              'expression': 'LITERAL',
+              'operand': true
+            }
+          }
+        ],
+        'facts': [
+          {
+            'fact': '[aanvraag]',
+            'function': { 'expression': 'CREATE' }
+          }
+        ],
+        'duties': []
+      }, ['ouder', 'minister'], { '[aanvraag]': 'supplied' })
+
+      const needLink = await core.claim(ssids['ouder'], {
+        'need': {
+          'act': '<<kinderbijslag aanvragen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+      const actionLink = await lawReg.take(ssids['ouder'], needLink, '<<kinderbijslag aanvragen>>', () => true)
+      const action = await core.get(actionLink, ssids['ouder'])
+      const needLink2 = await core.claim(ssids['minister'], {
+        'need': {
+          'act': '<<aanvraag kinderbijslag toekennen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        },
+        ...action.data
+      })
+
+      let errorMessage = ''
+      try {
+        await lawReg.take(ssids['minister'], needLink2, '<<aanvraag kinderbijslag toekennen>>', () => true)
+      } catch (e) {
+        errorMessage = e.message
+      }
+
+      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
+    })
+
     it('should be able to determine active duties being terminated', async () => {
       const core = lawReg.getAbundanceService().getCoreAPI()
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1613,9 +1613,9 @@ describe('discipl-law-reg', () => {
       const util = new Util(lawReg)
       const core = lawReg.getAbundanceService().getCoreAPI()
 
-      let { ssids, modelLink } = await util.setupModel(model, ['baker'], { 'baker': '[baker]' })
+      const { ssids, modelLink } = await util.setupModel(model, ['baker'], { 'baker': '[baker]' })
 
-      let needLink = await core.claim(ssids['baker'], {
+      const needLink = await core.claim(ssids['baker'], {
         'need': {
           'DISCIPL_FLINT_MODEL_LINK': modelLink
         }
@@ -1630,9 +1630,9 @@ describe('discipl-law-reg', () => {
         return creatingOptions[1]
       }
 
-      let firstBakeAction = await lawReg.take(ssids['baker'], needLink, '<<bake cookie>>', factResolver)
-      let secondBakeAction = await lawReg.take(ssids['baker'], firstBakeAction, '<<bake cookie>>', factResolver)
-      let eatAction = await lawReg.take(ssids['baker'], secondBakeAction, '<<eat cookie>>', factResolver)
+      const firstBakeAction = await lawReg.take(ssids['baker'], needLink, '<<bake cookie>>', factResolver)
+      const secondBakeAction = await lawReg.take(ssids['baker'], firstBakeAction, '<<bake cookie>>', factResolver)
+      const eatAction = await lawReg.take(ssids['baker'], secondBakeAction, '<<eat cookie>>', factResolver)
 
       const eatDetails = await core.get(eatAction, ssids['baker'])
 
@@ -1642,7 +1642,7 @@ describe('discipl-law-reg', () => {
         '[cookie]': firstBakeAction
       })
 
-      let eatAction2 = await lawReg.take(ssids['baker'], eatAction, '<<eat cookie>>', factResolver)
+      const eatAction2 = await lawReg.take(ssids['baker'], eatAction, '<<eat cookie>>', factResolver)
 
       const eatDetails2 = await core.get(eatAction2, ssids['baker'])
 
@@ -1795,9 +1795,9 @@ describe('discipl-law-reg', () => {
       const util = new Util(lawReg)
       const core = lawReg.getAbundanceService().getCoreAPI()
 
-      let { ssids, modelLink } = await util.setupModel(model, ['person'], { '[person]': 'person' })
+      const { ssids, modelLink } = await util.setupModel(model, ['person'], { '[person]': 'person' })
 
-      let needLink = await core.claim(ssids['person'], {
+      const needLink = await core.claim(ssids['person'], {
         'need': {
           'DISCIPL_FLINT_MODEL_LINK': modelLink
         }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1012,7 +1012,7 @@ describe('discipl-law-reg', () => {
         'facts': [
           { 'fact': '[ingezetene]', 'function': '[]', 'reference': 'art 1.1' },
           { 'fact': '[overheid]', 'function': '[]', 'reference': '' },
-          { 'fact': '[verwelkomst]', 'function': '<<>>', 'reference': '' }
+          { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE' }, 'reference': '' }
         ],
         'duties': [
         ]
@@ -1174,7 +1174,7 @@ describe('discipl-law-reg', () => {
         'facts': [
           {
             'fact': '[aanvraag]',
-            'function': '<<>>'
+            'function': { 'expression': 'CREATE' }
           }
         ],
         'duties': []
@@ -1222,7 +1222,7 @@ describe('discipl-law-reg', () => {
         'facts': [
           { 'fact': '[ingezetene]', 'function': '[]', 'reference': 'art 1.1' },
           { 'fact': '[overheid]', 'function': '[]', 'reference': '' },
-          { 'fact': '[verwelkomst]', 'function': '<<>>', 'reference': '' }
+          { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE' }, 'reference': '' }
         ],
         'duties': [
         ]
@@ -1545,7 +1545,7 @@ describe('discipl-law-reg', () => {
         'facts': [
           {
             'fact': '[cookie]',
-            'function': '<<>>'
+            'function': { 'expression': 'CREATE' }
           }
         ],
         'duties': []

--- a/test/modelValidator.spec.js
+++ b/test/modelValidator.spec.js
@@ -67,7 +67,7 @@ describe('The Flint Model validator', () => {
   it('should find errors with improperly named acts, facts, duties', async () => {
     const model = JSON.stringify({
       'acts': [{ 'act': 'test' }, { 'act': '<<test' }, { 'act': '<<>>' }, { 'act': '<<act>>' }],
-      'facts': [{ 'fact': 'test' }, { 'fact': '[test' }, { 'fact': '[]' }, { 'fact': '[fact]' }],
+      'facts': [{ 'fact': 'test' }, { 'fact': '[test' }, { 'fact': '<<>>' }, { 'fact': '[]' }, { 'fact': '[fact]' }],
       'duties': [{ 'duty': 'test' }, { 'duty': '<test' }, { 'duty': '<>' }, { 'duty': '<duty>' }]
     })
 
@@ -79,7 +79,7 @@ describe('The Flint Model validator', () => {
       'code': 'LR0001',
       'source': 'test',
       'message': 'Invalid name for identifier',
-      'offset': [168, 174],
+      'offset': [184, 190],
       'path': [
         'duties',
         0,
@@ -88,7 +88,7 @@ describe('The Flint Model validator', () => {
       'severity': 'ERROR'
     })
 
-    expect(errors.length).to.equal(12)
+    expect(errors.length).to.equal(15)
   })
 
   it('should find errors with duplicate identifiers', async () => {


### PR DESCRIPTION
This PR introduces the `CREATE` expression in favour of the `<<>>` notation that could be used as fact-function.

When defining a fact with the `CREATE` expression as function, the defined fact can no longer be injected from outside the model (for example with the `setupModel` method). The defined fact must follow out of an action with help of it's `create` property.

```json
{
    "acts": [
        {
            "act": "<<kinderbijslag aanvragen>>",
            "actor": "[ouder]",
            "action": "[aanvraag indienen]",
            "object": "[verzoek]",
            "recipient": "[minister]",
            "create": [
                "[aanvraag]"
            ]
        }
    ],
    "facts": [
        {
            "fact": "[aanvraag]",
            "function": {
                "expression": "CREATE"
            }
        }
    ]
}
```