### PR TITLE
PROJECTION expression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/law-reg",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2330,26 +2330,41 @@
       }
     },
     "@discipl/core-ephemeral": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@discipl/core-ephemeral/-/core-ephemeral-0.10.1.tgz",
-      "integrity": "sha512-RpFAKqEOMaqw3PMKZ6cdqJLxVqCG51XsxsylzDYXCFz0jm0OrZk1vwQaXJEovR+11Ccp8RFajkHsvHWnfFZpng==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@discipl/core-ephemeral/-/core-ephemeral-0.11.2.tgz",
+      "integrity": "sha512-kXfXissbKx1ug4EuLHPUsuL1Jmowictwhg7NiA/DKP/bUkchcsVUN8l46zAC53AJOpsFinh7zaQTEBcE9ZUpwA==",
       "dev": true,
       "requires": {
-        "@discipl/core-baseconnector": "0.2.1",
-        "axios": "0.18.1",
+        "@discipl/core-baseconnector": "0.2.2",
         "express": "4.17.1",
         "json-stable-stringify": "1.0.1",
-        "loglevel": "1.6.2",
-        "node-cache": "^4.2.0",
-        "node-forge": "0.8.4",
+        "lodash.clonedeep": "4.5.0",
+        "loglevel": "1.6.3",
+        "node-fetch": "^2.6.1",
+        "node-forge": "0.8.5",
         "rxjs": "6.5.2",
-        "ws": "6.2.1"
+        "ws": "7.1.1"
       },
       "dependencies": {
+        "@discipl/core-baseconnector": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/@discipl/core-baseconnector/-/core-baseconnector-0.2.2.tgz",
+          "integrity": "sha512-kwQCUmUWh9ApCrTBpZUrOTt65Q2L03SLtQMXxqPMM1Kw14euWGk8oywrD2Tu6QyX6MSBikbP8qdj2c6XeNn7Yw==",
+          "dev": true,
+          "requires": {
+            "json-stable-stringify": "1.0.1"
+          }
+        },
         "loglevel": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.2.tgz",
-          "integrity": "sha512-Jt2MHrCNdtIe1W6co3tF5KXGRkzF+TYffiQstfXa04mrss9IKXzAAXYWak8LbZseAQY03sH2GzMCMU0ZOUc9bg==",
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.6.3.tgz",
+          "integrity": "sha512-LoEDv5pgpvWgPF4kNYuIp0qqSJVWak/dML0RY74xlzMZiT9w77teNAwKYKWBTYjlokMirg+o3jBwp+vlLrcfAA==",
+          "dev": true
+        },
+        "node-fetch": {
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
           "dev": true
         }
       }
@@ -2637,24 +2652,6 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
       "dev": true,
       "optional": true
-    },
-    "axios": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-      "dev": true,
-      "requires": {
-        "follow-redirects": "1.5.10",
-        "is-buffer": "^2.0.2"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        }
-      }
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -3086,12 +3083,6 @@
         "strip-ansi": "^5.2.0",
         "wrap-ansi": "^5.1.0"
       }
-    },
-    "clone": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-      "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18=",
-      "dev": true
     },
     "codecov": {
       "version": "3.6.5",
@@ -4294,26 +4285,6 @@
         }
       }
     },
-    "follow-redirects": {
-      "version": "1.5.10",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-      "dev": true,
-      "requires": {
-        "debug": "=3.1.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -5292,6 +5263,12 @@
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
     "lodash.flattendeep": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
@@ -5428,18 +5405,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.43.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+      "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.26",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
-      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+      "version": "2.1.27",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+      "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
       "dev": true,
       "requires": {
-        "mime-db": "1.43.0"
+        "mime-db": "1.44.0"
       }
     },
     "mimic-fn": {
@@ -5824,16 +5801,6 @@
         }
       }
     },
-    "node-cache": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.1.tgz",
-      "integrity": "sha512-BOb67bWg2dTyax5kdef5WfU3X8xu4wPg+zHzkvls0Q/QpYycIFRLEEIdAx9Wma43DxG6Qzn4illdZoYseKWa4A==",
-      "dev": true,
-      "requires": {
-        "clone": "2.x",
-        "lodash": "^4.17.15"
-      }
-    },
     "node-fetch": {
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
@@ -5841,9 +5808,9 @@
       "dev": true
     },
     "node-forge": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.4.tgz",
-      "integrity": "sha512-UOfdpxivIYY4g5tqp5FNRNgROVNxRACUxxJREntJLFaJr1E0UEqFtUIk0F/jYx/E+Y6sVXd0KDi/m5My0yGCVw==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==",
       "dev": true
     },
     "node-modules-regexp": {
@@ -7689,12 +7656,12 @@
       }
     },
     "ws": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
-      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.1.tgz",
+      "integrity": "sha512-o41D/WmDeca0BqYhsr3nJzQyg9NF5X8l/UdnFNux9cS3lwB+swm8qGWX5rn+aD6xfBU3rGmtHij7g7x6LxFU3A==",
       "dev": true,
       "requires": {
-        "async-limiter": "~1.0.0"
+        "async-limiter": "^1.0.0"
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/law-reg",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Discipl Law and Regulation Compliance Library",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@babel/core": "7.10.1",
     "@babel/preset-env": "7.10.1",
     "@babel/register": "7.10.1",
-    "@discipl/core-ephemeral": "0.10.1",
+    "@discipl/core-ephemeral": "0.11.2",
     "babel-eslint": "10.0.1",
     "babel-plugin-dynamic-import-node": "2.2.0",
     "chai": "4.2.0",

--- a/src/identity_util.js
+++ b/src/identity_util.js
@@ -1,0 +1,16 @@
+class IdentityUtil {
+  /**
+   * Create an identity expression for a ssid
+   *
+   * @param {string} did - The did for the expression
+   * @returns {object} The identity expression
+   */
+  static identityExpression (did) {
+    return {
+      'expression': 'IS',
+      'operand': did
+    }
+  }
+}
+
+export default IdentityUtil

--- a/src/index.js
+++ b/src/index.js
@@ -435,7 +435,7 @@ class LawReg {
    * @property {string} caseLink - Link to the current case
    * @property {object} [facts] - Parsed facts from flint model
    * @property {string} [previousFact] - last fact that was considered in the context
-   * @property {boolean} [myself] - `IS:` constructions will be resolved iff it concerns the person themselves
+   * @property {boolean} [myself] - `IS:` constructions will be resolved if it concerns the person themselves
    * @property {object} [factReference] - Map from fact names to fact links in a published FLINT model
    * @property {array} [listNames] - Names of (subsequent) lists that belong to the current context
    * @property {array} [listIndices] - Index of current location in the list

--- a/src/index.js
+++ b/src/index.js
@@ -311,17 +311,27 @@ class LawReg {
       case 'PROJECTION':
         logger.debug('Switch case: PROJECTION')
         const core = this.abundance.getCoreAPI()
+        const lawregContext = context
 
-        const factWithCreateExpression = fact.operands[0]
-        const projectedFact = fact.operands[1]
-        const caseLink = await this.checkFact(factWithCreateExpression, ssid, context)
+        if (!fact.context || fact.context.length === 0) {
+          throw new Error("A 'context' array must be given for the PROJECTION expression")
+        }
+
+        // Walk down the context array and resolve each fact
+        const caseLink = await fact.context.reduce(async (caseLink, curr) => {
+          const factContext = await core.get(caseLink, ssid)
+
+          if (Object.keys(factContext.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(curr)) {
+            return factContext.data.DISCIPL_FLINT_FACTS_SUPPLIED[curr]
+          }
+
+          return undefined
+        }, await this.checkFact(fact.context.shift(), ssid, lawregContext))
+
         const caseObject = await core.get(caseLink, ssid)
 
-        if (Object.keys(caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(projectedFact)) {
-          const projectionResult = caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED[projectedFact]
-
-          logger.debug('Resolving fact', fact, 'as', projectionResult, 'by determining earlier creation')
-          return projectionResult
+        if (Object.keys(caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(fact.fact)) {
+          return caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED[fact.fact]
         }
 
         return undefined

--- a/src/index.js
+++ b/src/index.js
@@ -290,7 +290,9 @@ class LawReg {
         logger.debug('Switch case: CREATE')
         let finalCreateResult = await this.checkCreatedFact(context.previousFact, ssid, context)
 
-        if (!finalCreateResult) {
+        if (!finalCreateResult | !fact.operands) {
+          logger.debug('Resolving fact', fact, 'as', finalCreateResult, 'by determining earlier creation')
+
           this._extendContextExplanationWithResult(context, finalCreateResult)
           return finalCreateResult
         }

--- a/src/index.js
+++ b/src/index.js
@@ -319,21 +319,23 @@ class LawReg {
           throw new Error("A 'context' array must be given for the PROJECTION expression")
         }
 
-        // Walk down the context array and resolve each fact
-        const caseLink = await fact.context.reduce(async (caseLink, curr) => {
-          const factContext = await core.get(caseLink, ssid)
+        const caseLink = await fact.context.slice(1).reduce(async (previousCaseLink, currentContextFact) => {
+          if (previousCaseLink) {
+            const factContext = await core.get(previousCaseLink, ssid)
 
-          if (Object.keys(factContext.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(curr)) {
-            return factContext.data.DISCIPL_FLINT_FACTS_SUPPLIED[curr]
+            if (Object.keys(factContext.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(currentContextFact)) {
+              return factContext.data.DISCIPL_FLINT_FACTS_SUPPLIED[currentContextFact]
+            }
           }
-
           return undefined
-        }, await this.checkFact(fact.context.shift(), ssid, lawregContext))
+        }, await this.checkFact(fact.context[0], ssid, lawregContext))
 
-        const caseObject = await core.get(caseLink, ssid)
+        if (caseLink) {
+          const caseObject = await core.get(caseLink, ssid)
 
-        if (Object.keys(caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(fact.fact)) {
-          return caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED[fact.fact]
+          if (Object.keys(caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(fact.fact)) {
+            return caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED[fact.fact]
+          }
         }
 
         return undefined

--- a/src/index.js
+++ b/src/index.js
@@ -287,8 +287,23 @@ class LawReg {
         this._extendContextExplanationWithResult(context, literalValue)
         return literalValue
       case 'CREATE':
-        logger.debug('Swithc case: CREATE')
-        const finalCreateResult = await this.checkCreatedFact(context.previousFact, ssid, context)
+        logger.debug('Switch case: CREATE')
+        let finalCreateResult = await this.checkCreatedFact(context.previousFact, ssid, context)
+
+        if (!finalCreateResult) {
+          this._extendContextExplanationWithResult(context, finalCreateResult)
+          return finalCreateResult
+        }
+
+        for (const op of fact.operands) {
+          const factExists = await this.checkFact(op, ssid, context)
+
+          if (!factExists) {
+            finalCreateResult = false
+            break
+          }
+        }
+
         logger.debug('Resolving fact', fact, 'as', finalCreateResult, 'by determining earlier creation')
         this._extendContextExplanationWithResult(context, finalCreateResult)
 

--- a/src/index.js
+++ b/src/index.js
@@ -308,6 +308,23 @@ class LawReg {
         this._extendContextExplanationWithResult(context, finalCreateResult)
 
         return finalCreateResult
+      case 'PROJECTION':
+        logger.debug('Switch case: PROJECTION')
+        const core = this.abundance.getCoreAPI()
+
+        const factWithCreateExpression = fact.operands[0]
+        const projectedFact = fact.operands[1]
+        const caseLink = await this.checkFact(factWithCreateExpression, ssid, context)
+        const caseObject = await core.get(caseLink, ssid)
+
+        if (Object.keys(caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED).includes(projectedFact)) {
+          const projectionResult = caseObject.data.DISCIPL_FLINT_FACTS_SUPPLIED[projectedFact]
+
+          logger.debug('Resolving fact', fact, 'as', projectionResult, 'by determining earlier creation')
+          return projectionResult
+        }
+
+        return undefined
       default:
         logger.debug('Switch case: default')
         if (typeof fact === 'string') {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import { ModelValidator } from './modelValidator'
 import { BigUtil } from './big_util'
 
 import * as log from 'loglevel'
-import { BaseConnector } from '@discipl/core-baseconnector'
 import Big from 'big.js'
 import IdentityUtil from './identity_util'
 
@@ -17,7 +16,6 @@ const DISCIPL_FLINT_GLOBAL_CASE = 'DISCIPL_FLINT_GLOBAL_CASE'
 const DISCIPL_FLINT_PREVIOUS_CASE = 'DISCIPL_FLINT_PREVIOUS_CASE'
 const DISCIPL_FLINT_MODEL_LINK = 'DISCIPL_FLINT_MODEL_LINK'
 
-const DISCIPL_IS_MARKER = 'IS:'
 const DISCIPL_ANYONE_MARKER = 'ANYONE'
 
 const logger = log.getLogger('disciplLawReg')
@@ -386,21 +384,6 @@ class LawReg {
       return { ...context, explanation: newExplanation }
     } else {
       return context
-    }
-  }
-
-  /**
-   * Extract the DID being referred, if the input is an IS-construction
-   *
-   * @param {string} functionRef - String with a possible IS-construction
-   * @returns {string|undefined} - The DID being referred if it is an IS-construction, undefined otherwise
-   */
-  static extractDidFromIsConstruction (functionRef) {
-    if (typeof functionRef === 'string' && functionRef.startsWith(DISCIPL_IS_MARKER)) {
-      const possibleDid = functionRef.replace('IS:', '')
-      if (BaseConnector.isDid(possibleDid)) {
-        return possibleDid
-      }
     }
   }
 
@@ -1113,7 +1096,7 @@ class LawReg {
       })
     }
 
-    throw new Error('Action ' + act + ' is not allowed')
+    throw new Error('Action ' + act + ' is not allowed due to ' + checkActionInfo.invalidReasons)
   }
 
   /**

--- a/src/util.js
+++ b/src/util.js
@@ -1,3 +1,5 @@
+import IdentityUtil from './identity_util'
+
 const CERTS = [
   {
     'cert': `-----BEGIN CERTIFICATE-----
@@ -239,7 +241,7 @@ class Util {
       }
       const values = actors.map((actor) => {
         if (allActors.includes(actor)) {
-          return 'IS:' + ssids[actor].did
+          return IdentityUtil.identityExpression(ssids[actor].did)
         } else {
           return factFunctionSpec[fact]
         }
@@ -264,13 +266,11 @@ class Util {
     const needSsid = await ephemeralConnector.newIdentity(cert)
     await this.core.allow(needSsid)
 
-    const needLink = await this.core.claim(needSsid, {
+    let caseLink = await this.core.claim(needSsid, {
       'need': {
         'DISCIPL_FLINT_MODEL_LINK': modelLink
       }
     })
-
-    let caseLink = needLink
 
     const factResolver = (fact) => {
       if (facts[fact]) {

--- a/src/util.js
+++ b/src/util.js
@@ -243,7 +243,7 @@ class Util {
         if (allActors.includes(actor)) {
           return IdentityUtil.identityExpression(ssids[actor].did)
         } else {
-          return factFunctionSpec[fact]
+          return IdentityUtil.identityExpression(factFunctionSpec[fact])
         }
       })
 

--- a/test/flint-example-awb.json
+++ b/test/flint-example-awb.json
@@ -362,8 +362,7 @@
       "explanation": "",
       "fact": "[aanvraag]",
       "function": {
-        "expression": "CREATE",
-        "operands": []
+        "expression": "CREATE"
       },
       "reference": "art. 1:3 lid 1 en 3 Awb",
       "version": "2-[19980101]-[jjjjmmdd]",

--- a/test/flint-example-awb.json
+++ b/test/flint-example-awb.json
@@ -361,7 +361,10 @@
     {
       "explanation": "",
       "fact": "[aanvraag]",
-      "function": { "expression": "CREATE" },
+      "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "reference": "art. 1:3 lid 1 en 3 Awb",
       "version": "2-[19980101]-[jjjjmmdd]",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",

--- a/test/flint-example-lerarenbeurs.json
+++ b/test/flint-example-lerarenbeurs.json
@@ -959,7 +959,10 @@
     },
     {
       "fact": "[besluit]",
-      "function": { "expression": "CREATE" },
+      "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "2-[19980101]-[jjjjmmdd]",
       "art": "art. 1:3 lid 1 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=1&z=2017-03-01&g=2017-03-01",
@@ -1076,7 +1079,10 @@
     },
     {
       "fact": "[aanvraag]",
-      "function": { "expression": "CREATE" },
+      "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "2-[19980101]-[jjjjmmdd]",
       "art": "art. 1:3 lid 1 en 3 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",
@@ -1094,7 +1100,10 @@
     },
     {
       "fact": "[aanvraag subsidieverlening]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 4:35 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35",
@@ -1103,7 +1112,10 @@
     },
     {
       "fact": "[aanvraag subsidie voor studiekosten]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 7 lid 1 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=1",
@@ -1112,7 +1124,10 @@
     },
     {
       "fact": "[aanvraag subsidie voor studieverlof]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 8 lid 1 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=1",
@@ -1121,7 +1136,10 @@
     },
     {
       "fact": "[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 7 lid 2 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=2",
@@ -1148,7 +1166,10 @@
     },
     {
       "fact": "[aanvraagformulieren studieverlof op de website van de Dienst Uitvoering Onderwijs]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 8 lid 2 Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=2",
@@ -1175,7 +1196,10 @@
     },
     {
       "fact": "[subsidieontvanger studiekosten]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 3 lid 1 onder a Sbl",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
@@ -1193,7 +1217,10 @@
     },
     {
       "fact": "[formulier voor het indienen van aanvragen en het verstrekken van gegevens is vastgesteld door bestuursorgaan]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "2-[19940101]-[jjjjmmdd]",
       "art": "art. 4:4 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4&z=2017-03-01&g=2017-03-01",
@@ -2794,7 +2821,10 @@
     },
     {
       "fact": "[besluit tot verlenen subsidie voor kosten in verband met het verlenen van studieverlof aan de leraar]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art.3 lid 1, onder b Slb",
       "juriconnect": "",
@@ -2803,7 +2833,10 @@
     },
     {
       "fact": "[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 4:23, lid 1 Awb",
       "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.1&artikel=4:23&lid=1",
@@ -2812,7 +2845,10 @@
     },
     {
       "fact": "[verzoek tot bewijs van het behalen van ten minste vijftien studiepunten]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "Art. 19, onder b Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
@@ -2830,7 +2866,10 @@
     },
     {
       "fact": "[verzoek tot bewijs van betaling van collegegeld]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "Art. 19, onder a Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
@@ -2873,7 +2912,10 @@
     },
     {
       "fact": "[leraar heeft minder dan 15 studiepunten gehaald]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "Art. 13, lid 1  Slb",
       "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
@@ -2882,7 +2924,10 @@
     },
     {
       "fact": "[leraar heeft binnen 2 maanden na verstrekking van de subsidie de aanvraag voor subsidie ingetrokken]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "Art. 13, lid 2, aanhef en omnder a  Slb",
       "juriconnect": "3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
@@ -2960,7 +3005,10 @@
     },
     {
       "fact": "[subsidieontvanger]",
-      "function": { "expression": "CREATE" },
+            "function": {
+        "expression": "CREATE",
+        "operands": []
+      },
       "version": "",
       "art": "art. 5.7 lid 1, aanhef en onder b. Kaderregeling subsidies OCW, SZW en VWS",
       "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",

--- a/test/flint-example-lerarenbeurs.json
+++ b/test/flint-example-lerarenbeurs.json
@@ -23,14 +23,15 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",
           "validFrom": "01-03-2017",
           "validTo": "09-03-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",
           "citation": "art. 1:3 lid 3 Awb",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
-      "explanation": "{De ontvanger [bestuursorgaan] kan worden afgeleid van de definitie van â€˜besluitâ€™ in artikel 1:3 lid 1 Awb.}\r\n\r\nAanvrager wordt als term wel gebruikt in de Awb. In de Awb is er geen definitie gegeven. Ik heb hier dus ook geen verwijzing voor. Ik heb wel een reden gevonden waarom de Awb het in een aantal artikelen wel over aanvrager heeft. Dat is omdat een aanvrager niet altijd de belanghebbende is. Zie T&C Awb, commentaar op art. 3:13 Awb, J. Verbeek."
+      "explanation": "{De ontvanger [bestuursorgaan] kan worden afgeleid van de definitie van â\u20AC˜besluitâ\u20AC™ in artikel 1:3 lid 1 Awb.}\r\n\r\nAanvrager wordt als term wel gebruikt in de Awb. In de Awb is er geen definitie gegeven. Ik heb hier dus ook geen verwijzing voor. Ik heb wel een reden gevonden waarom de Awb het in een aantal artikelen wel over aanvrager heeft. Dat is omdat een aanvrager niet altijd de belanghebbende is. Zie T&C Awb, commentaar op art. 3:13 Awb, J. Verbeek."
     },
     {
       "act": "<<bekendmaken van een besluit>>",
@@ -55,11 +56,12 @@
       ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.6&artikel=3:40&z=2017-04-01&g=2017-04-01",
           "validFrom": "01-04-2017",
           "validTo": "11-06-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.6&artikel=3:40&z=2017-04-01&g=2017-04-01",
           "citation": "art. 3:40 Awb",
-          "text": "{Een besluit treedt niet in werking voordat het is bekendgemaakt.}"
+          "text": "{Een besluit treedt niet in werking voordat het is bekendgemaakt.}",
+          "explanation": ""
         }
       ],
       "explanation": "Artikel 3.40 Awb impliceert dat het bestuursorgaan dat bevoegd is een besluit te nemen, ook bevoegd is het besluit bekend maken. Ook al staat dat er niet expliciet, dat is de interpretatie die hier gekozen is.\r\n\r\nHet kan natuurlijk altijd dat er regels zijn die andere(n) (bestuursorga(a)n(en)) toestaan om een besluit bekend te maken, of regels die de bevoegdheid om besluiten bekend te maken beperken. Die regels hebben we nog niet gevonden.\r\nArtikel 3.41 Awb gaat over de wijze waarop het bekendmaken gebeurt."
@@ -103,11 +105,12 @@
       ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&z=2017-03-10&g=2017-03-10",
           "validFrom": "10-03-2017",
           "validTo": "31-03-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&z=2017-03-10&g=2017-03-10",
+          "citation": "art. 4:5 Awb",
           "text": "{Het bestuursorgaan kan besluiten de aanvraag niet te behandelen, indien:\r\na. de aanvrager niet heeft voldaan aan enig wettelijk voorschrift voor het in behandeling nemen van de aanvraag, of\r\nb. de aanvraag geheel of gedeeltelijk is geweigerd op grond van artikel 2:15, of\r\nc. de verstrekte gegevens en bescheiden onvoldoende zijn voor de beoordeling van de aanvraag of voor de voorbereiding van de beschikking,\r\nmits de aanvrager de gelegenheid heeft gehad de aanvraag binnen een door het bestuursorgaan gestelde termijn aan te vullen.\r\n(...)\r\n4 Een besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken.}",
-          "citation": "art. 4:5 Awb"
+          "explanation": ""
         }
       ],
       "explanation": "Hoe omgaan met voorwaarde [besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken]?\r\n\r\nHet besluit is nog niet bekendgemaakt op het moment dat het wordt genomen. Kan dat dan wel als voorwaarde voor het nemen van een besluit worden gesteld?\r\n(Ik zou zeggen dat dat wel kan. Bij het nemen van het besluit wordt ervan uitgegaan dat het besluit binnen de termijn wordt bekendgemaakt. Als later blijkt dat dat toch niet is gebeurd, kunnen belanghebbenden immuniteit tegen het besluit claimen.)\r\n\r\nNav vraag of je wel aanvrager moet egbruiken als deze term niet wordt gedefinieerd in de Awb.\r\nAanvrager wordt als term wel gebruikt in de Awb. In de Awb is er geen definitie gegeven. Ik heb hier dus ook geen verwijzing voor. Ik heb wel een reden gevonden waarom de Awb het in een aantal artikelen wel over aanvrager heeft. Dat is omdat een aanvrager niet altijd de belanghebbende is. Zie T&C Awb, commentaar op art. 3:13 Awb, J. Verbeek."
@@ -134,11 +137,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4&z=2017-03-01&g=2017-03-01",
           "validFrom": "01-03-2017",
           "validTo": "09-03-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4&z=2017-03-01&g=2017-03-01",
+          "citation": "art. 4:4 Awb",
           "text": "{Het bestuursorgaan dat bevoegd is op de aanvraag te beslissen, kan voor het indienen van aanvragen en het verstrekken van gegevens een formulier vaststellen, voor zover daarin niet is voorzien bij wettelijk voorschrift.}",
-          "citation": "art. 4:4 Awb"
+          "explanation": ""
         }
       ],
       "explanation": "Heeft het expliciet beschrijven van deze handeling een functie? (Zo ja, welke?)"
@@ -205,13 +209,15 @@
       ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
+          "citation": "art. 3 lid 1, aanhef en onder a, Slb",
           "text": "",
-          "citation": "art. 3 lid 1, aanhef en onder a, Slb"
+          "explanation": ""
         }
       ],
-      "explanation": "Definitie bachelor en masteropleidingen in art. 1 definities stellen eisen aan land en status/erkenning opleiding.\r\n\r\nBevat het besluit ook de hoogte van het subsidiebedrag? In de beschikking staat dit bedrag wel, de vraag is of we het modelleren als een aparte handeling.\r\n\r\nDit is een lastig punt:\r\n- om te kunnen besluiten de subsidie te verlenen moet je weten hoe hoog het bedrag is (om vast te stellen of er nog budget is*)\r\n- waarom zou je berekenen hoe hoog de subsidie is als je nog niet weet of iemand in aanmerking komt voor subsidie\r\n- de berekening van de hoogte van het bedrag is in een apart artikel geregeld\r\n- de subsidie voor studieverlof aan bevoegd gezag wordt apart verstrekt, maar dit bedrag is wel nodig om te kunnen vaststellen of er nog budget is.\r\n\r\nEr zijn geen aparte gronden voor afwijzing en buiten behandeling stellen. Impliceert dat, dat wordt afgewezen als niet wordt voldaan aan een voorwaarde voor verstrekken, en alleen buiten behandeling wordt gesteld op grond van art. 4:5 Awb?\r\nAntwoord 10 juli 2019: \r\nRani: Ja, zie artikel 4:31 Awb (In Github de verkeerde verwijzing. Dit moet art 4:35 zijn, want hier staan de algemene afwijzingsgronden)\r\nna overleg met Robert: Dit zijn 2 besluiten die je bekent maakt in 1 document. Vgl. meeromvattende beschikking Vw 2000. \r\nNav deze vraag en antwoord is artikel 4:35 Awb gemodelleerd\r\n\r\nAls de leraar geen subsidie voor studiekosten ontvangt omdat deze al op andere wijze van de minister een tegemoetkoming in de studiekosten ontvangt, wordt dan ook de subsidie op de kosten van studieverlof geweigerd (art. 10 Slb)?\r\nAntwoord 29 augustus 2019:\r\nRani: Uit de toelichting bij artikel 10 Sls haal ik dat de wet studiefinanciering 200 en de wet Wet Tegemoetkoming Onderwijsbijdrage en Studiekosten de wetten zijn waar artikel 10 het over heeft. In die wetten zie ik geen mogelijkheden om studieverlof toe te kennen. Op basis hiervan meen ik dat de aanvraag van subsidie voor studieverlof niet afgewezen hoeft te worden als de subsidie voor studiekosten wordt afgewezen.\r\n\r\n*)  Het bepalen of er nog budget is, doe je in de praktijk alleen als het budget bijna op is. En alleen als het budget bijna op is, is de volgorde van indienen relevant."
+      "explanation": "Definitie bachelor en masteropleidingen in art. 1 definities stellen eisen aan land en status\/erkenning opleiding.\r\n\r\nBevat het besluit ook de hoogte van het subsidiebedrag? In de beschikking staat dit bedrag wel, de vraag is of we het modelleren als een aparte handeling.\r\n\r\nDit is een lastig punt:\r\n- om te kunnen besluiten de subsidie te verlenen moet je weten hoe hoog het bedrag is (om vast te stellen of er nog budget is*)\r\n- waarom zou je berekenen hoe hoog de subsidie is als je nog niet weet of iemand in aanmerking komt voor subsidie\r\n- de berekening van de hoogte van het bedrag is in een apart artikel geregeld\r\n- de subsidie voor studieverlof aan bevoegd gezag wordt apart verstrekt, maar dit bedrag is wel nodig om te kunnen vaststellen of er nog budget is.\r\n\r\nEr zijn geen aparte gronden voor afwijzing en buiten behandeling stellen. Impliceert dat, dat wordt afgewezen als niet wordt voldaan aan een voorwaarde voor verstrekken, en alleen buiten behandeling wordt gesteld op grond van art. 4:5 Awb?\r\nAntwoord 10 juli 2019: \r\nRani: Ja, zie artikel 4:31 Awb (In Github de verkeerde verwijzing. Dit moet art 4:35 zijn, want hier staan de algemene afwijzingsgronden)\r\nna overleg met Robert: Dit zijn 2 besluiten die je bekent maakt in 1 document. Vgl. meeromvattende beschikking Vw 2000. \r\nNav deze vraag en antwoord is artikel 4:35 Awb gemodelleerd\r\n\r\nAls de leraar geen subsidie voor studiekosten ontvangt omdat deze al op andere wijze van de minister een tegemoetkoming in de studiekosten ontvangt, wordt dan ook de subsidie op de kosten van studieverlof geweigerd (art. 10 Slb)?\r\nAntwoord 29 augustus 2019:\r\nRani: Uit de toelichting bij artikel 10 Sls haal ik dat de wet studiefinanciering 200 en de wet Wet Tegemoetkoming Onderwijsbijdrage en Studiekosten de wetten zijn waar artikel 10 het over heeft. In die wetten zie ik geen mogelijkheden om studieverlof toe te kennen. Op basis hiervan meen ik dat de aanvraag van subsidie voor studieverlof niet afgewezen hoeft te worden als de subsidie voor studiekosten wordt afgewezen.\r\n\r\n*)  Het bepalen of er nog budget is, doe je in de praktijk alleen als het budget bijna op is. En alleen als het budget bijna op is, is de volgorde van indienen relevant."
     },
     {
       "act": "<<minister verstrekt subsidie lerarenbeurs aan bevoegd gezag>>",
@@ -253,10 +259,12 @@
       ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
+          "citation": "art. 3.1 lid 1, aanhef en onder b, Slb",
           "text": "",
-          "citation": "art. 3.1 lid 1, aanhef en onder b, Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -275,7 +283,6 @@
         ]
       },
       "create": [
-        "[leraar met aanvraag]",
         "[aanvraag]",
         "[aanvraag subsidieverlening]",
         "[aanvraag subsidie voor studiekosten]",
@@ -284,10 +291,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=1",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=1",
+          "citation": "art. 7 lid 1 Slb",
           "text": "{De subsidie voor studiekosten wordt aangevraagd door de leraar.}",
-          "citation": "art. 7 lid 1 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -314,10 +323,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=1",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=1",
+          "citation": "art. 8 lid 1 Slb",
           "text": "{De subsidie voor studieverlof wordt door de leraar aangevraagd voor het bevoegd gezag.}",
-          "citation": "art. 8 lid 1 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -341,11 +352,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
           "validFrom": "01-04-2020",
           "validTo": "24-06-2022",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
+          "citation": "art. 13 lid 1 Slb",
           "text": "{De minister kan de subsidie voor studiekosten terugvorderen indien de leraar in de subsidieperiode minder dan vijftien studiepunten behaalt}",
-          "citation": "art. 13 lid 1 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -367,13 +379,14 @@
         "[terugvordering]"
       ],
       "terminate": [],
-      "version": "",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
+          "citation": "art. 13 lid 2 Slb",
           "text": "",
-          "citation": "art. 13 lid 2 Slb"
+          "explanation": ""
         }
       ],
       "explanation": "[leraar heeft binnen 2 maanden na verstrekking van de subsidie de aanvraag voor subsidie ingetrokken]  is naar mijn mening ook een preconditie. Als de leraar zijn aanvraag niet intrekt binnen 2 maanden, kan de minister geen subsidie terugvorderen."
@@ -392,10 +405,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
+          "citation": "art. 13 lid 2 Slb",
           "text": "",
-          "citation": "art. 13 lid 2 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -411,10 +426,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=3",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=3",
+          "citation": "art. 13 lid 3 Slb",
           "text": "",
-          "citation": "art. 13 lid 3 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -433,11 +450,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=16&z=2019-04-01&g=2019-04-01",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=16&z=2019-04-01&g=2019-04-01",
+          "citation": "art. 16 Slb",
           "text": "",
-          "citation": "art. 16 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -455,11 +473,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
+          "citation": "art. 19 Slb",
           "text": "",
-          "citation": "art. 19 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -477,11 +496,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
+          "citation": "art. 19 Slb",
           "text": "",
-          "citation": "art. 19 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -504,11 +524,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
+          "citation": "art. 19 Slb",
           "text": "",
-          "citation": "art. 19 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -531,11 +552,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19&z=2019-04-01&g=2019-04-01",
+          "citation": "art. 19 Slb",
           "text": "",
-          "citation": "art. 19 Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -551,31 +573,35 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
+          "citation": "art. 13 lid 2, onder b. Slb",
           "text": "",
-          "citation": "art. 13 lid 2, onder b. Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
     },
     {
       "act": "<<leraar trekt aanvraag subsidie voor studiekosten in>>",
-      "actor": "[leraar]",
+      "actor": "[leraar met aanvraag]",
       "action": "[intrekken]",
       "object": "[aanvraag subsidie voor studiekosten]",
       "recipient": "[minister van Onderwijs, Cultuur en Wetenschap]",
       "preconditions": "[binnen twee maanden na het verstrekken van de subsidie]",
       "create": [],
-      "terminate": [],
+      "terminate": [
+        "[aanvraag]"
+      ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
+          "citation": "art. 13 lid 2, onder b. Slb",
           "text": "",
-          "citation": "art. 13 lid 2, onder b. Slb"
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -594,14 +620,14 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",
           "validFrom": "01-01-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",
           "citation": "art. 5.7 lid 1, aanhef en onder b. Kaderregeling subsidies OCW, SZW en VWS",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
-      "version": "",
-      "sourcetext": "",
       "explanation": ""
     },
     {
@@ -621,10 +647,12 @@
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",
           "validFrom": "01-01-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",
           "citation": "art. 5.7 lid 1, aanhef en onder b. Kaderregeling subsidies OCW, SZW en VWS",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -648,14 +676,14 @@
       ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=24&lid=2",
           "validFrom": "24-06-2022",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=24&lid=2",
           "citation": "art. 24 lid 2 Slb",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
-      "version": "",
-      "sourcetext": "",
       "explanation": "Hoe zit het met de mogelijkheid om middelen voor subsidieverlof aan andere activiteiten te besteden (art. 24 lid 2 Slb)?"
     },
     {
@@ -673,10 +701,12 @@
       ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=4&artikel=26",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=4&artikel=26",
           "citation": "art. 26 Slb",
-          "text": "{De minister kan een of meer bepalingen van deze regeling buiten toepassing laten of daarvan afwijken voor zover deze toepassing, gelet op het belang dat deze regeling beoogt te beschermen, zal leiden tot onbillijkheid van overwegende aard.}"
+          "text": "{De minister kan een of meer bepalingen van deze regeling buiten toepassing laten of daarvan afwijken voor zover deze toepassing, gelet op het belang dat deze regeling beoogt te beschermen, zal leiden tot onbillijkheid van overwegende aard.}",
+          "explanation": ""
         }
       ],
       "explanation": "Heb de tekst in de preconditie gelijkgetrokken met de tekst in de facts"
@@ -696,10 +726,12 @@
       ],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=4&artikel=26",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=4&artikel=26",
           "citation": "art. 26 Slb",
-          "text": "{De minister kan een of meer bepalingen van deze regeling buiten toepassing laten of daarvan afwijken voor zover deze toepassing, gelet op het belang dat deze regeling beoogt te beschermen, zal leiden tot onbillijkheid van overwegende aard.}"
+          "text": "{De minister kan een of meer bepalingen van deze regeling buiten toepassing laten of daarvan afwijken voor zover deze toepassing, gelet op het belang dat deze regeling beoogt te beschermen, zal leiden tot onbillijkheid van overwegende aard.}",
+          "explanation": ""
         }
       ],
       "explanation": "Heb de tekst in de preconditie gelijkgetrokken met de tekst in de facts"
@@ -742,13 +774,14 @@
       "terminate": [
         "[aanvraag]"
       ],
-      "version": "",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35",
           "validFrom": "01-07-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35",
           "citation": "art.4:35 Awb",
-          "text": "{1 De subsidieverlening kan in ieder geval worden geweigerd indien een gegronde reden bestaat om aan te nemen dat:\r\n\r\na. de activiteiten niet of niet geheel zullen plaatsvinden;\r\n\r\nb. de aanvrager niet zal voldoen aan de aan de subsidie verbonden verplichtingen;\r\n\r\nc. de aanvrager niet op een behoorlijke wijze rekening en verantwoording zal afleggen omtrent de verrichte activiteiten en de daaraan verbonden uitgaven en inkomsten, voor zover deze voor de vaststelling van de subsidie van belang zijn.\r\n\r\n2 De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager:\r\n\r\na. in het kader van de aanvraag onjuiste of onvolledige gegevens heeft verstrekt en de verstrekking van deze gegevens tot een onjuiste beschikking op de aanvraag zou hebben geleid, of\r\n\r\nb. failliet is verklaard of aan hem surséance van betaling is verleend of ten aanzien van hem de schuldsaneringsregeling natuurlijke personen van toepassing is verklaard, dan wel een verzoek daartoe bij de rechtbank is ingediend.\r\n\r\n3 De subsidieverlening wordt voorts geweigerd indien de verstrekking van subsidie naar het oordeel van het bestuursorgaan niet verenigbaar is met het bepaalde in de artikelen 107 en 108 van het Verdrag betreffende de werking van de Europese Unie.}"
+          "text": "{1 De subsidieverlening kan in ieder geval worden geweigerd indien een gegronde reden bestaat om aan te nemen dat:\r\n\r\na. de activiteiten niet of niet geheel zullen plaatsvinden;\r\n\r\nb. de aanvrager niet zal voldoen aan de aan de subsidie verbonden verplichtingen;\r\n\r\nc. de aanvrager niet op een behoorlijke wijze rekening en verantwoording zal afleggen omtrent de verrichte activiteiten en de daaraan verbonden uitgaven en inkomsten, voor zover deze voor de vaststelling van de subsidie van belang zijn.\r\n\r\n2 De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager:\r\n\r\na. in het kader van de aanvraag onjuiste of onvolledige gegevens heeft verstrekt en de verstrekking van deze gegevens tot een onjuiste beschikking op de aanvraag zou hebben geleid, of\r\n\r\nb. failliet is verklaard of aan hem surséance van betaling is verleend of ten aanzien van hem de schuldsaneringsregeling natuurlijke personen van toepassing is verklaard, dan wel een verzoek daartoe bij de rechtbank is ingediend.\r\n\r\n3 De subsidieverlening wordt voorts geweigerd indien de verstrekking van subsidie naar het oordeel van het bestuursorgaan niet verenigbaar is met het bepaalde in de artikelen 107 en 108 van het Verdrag betreffende de werking van de Europese Unie.}",
+          "explanation": ""
         }
       ],
       "explanation": "Omdat in artikel 10 Sbl ook de weigeringsgronden van artikel 4:35 Awb genoemd worden als weigeringsgronden, hebben we  artikel 4:35 Awb toegevoegd. Hierbij heb je dus ook een andere actor en geïnteresseerde partij. \r\n19-7 Bij kolom interested party aanvrager gewijzigd in belanghebbende, omdat belanghebbende de wettelijke term is. Er bestaat in de Awb niet zoiets als een aanvrager. De belanghebbende doet een aanvraag"
@@ -772,10 +805,10 @@
           "validTo": "31-12-2019",
           "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=10&z=2019-04-01&g=2019-04-01",
           "citation": "art. 10 Slb",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
-      "version": "",
       "explanation": "Als niet aan 1 van de andere voorwaarden voor het verlenen van de subsidie wordt voldaan, moet er ook worden afgewezen, neem ik aan."
     },
     {
@@ -784,18 +817,19 @@
       "action": "[verdelen]",
       "object": "[beschikbare bedrag voor de subsidieregeling lerarenbeurs]",
       "recipient": "[Regering]",
-      "preconditions": "",
+      "preconditions": "[]",
       "create": [
         "<bekend maken besluit>"
       ],
       "terminate": [],
-      "version": "",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=6&lid=1",
           "validFrom": "25-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=6&lid=1",
           "citation": "art. 6 lid 1 Slb",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
       "explanation": "De minister in artikel 6, eerste lid Slb is ten aanzien van de uitvoering hiervan verantwoording schuldig aan de wetgevende macht. De wetgevende macht is hier regering. Dit aanpassen in de excel. Regering is interesed party."
@@ -806,15 +840,17 @@
       "action": "[verdelen]",
       "object": "[concrete verdeling van het beschikbare budget in een studiejaar per soort onderwijs]",
       "recipient": "[Regering]",
-      "preconditions": "",
+      "preconditions": "[]",
       "create": [],
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=22",
           "validFrom": "25-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=22",
           "citation": "art. 22 Slb",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
       "explanation": "De minister in artikel 6, eerste lid Slb is ten aanzien van de uitvoering hiervan verantwoording schuldig aan de wetgevende macht. De wetgevende macht is hier regering. Dit aanpassen in de excel. Regering is interesed party."
@@ -825,20 +861,21 @@
       "action": "[berekenen]",
       "object": "[hoogte van de subsidie voor studiekosten]",
       "recipient": "[leraar]",
-      "preconditions": "",
+      "preconditions": "[]",
       "create": [
         "[vergoeding kosten collegegeld]",
         "[vergoeding studiemiddelen]",
-        "[vergoeding reiskosten]",
-        ""
+        "[vergoeding reiskosten]"
       ],
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=15",
           "validFrom": "25-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=15",
           "citation": "art. 15 Slb",
-          "text": ""
+          "text": "",
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -849,18 +886,19 @@
       "action": "[berekenen]",
       "object": "[hoogte van de subsidie voor studieverlof]",
       "recipient": "[bevoegd gezag]",
-      "preconditions": "",
+      "preconditions": "[]",
       "create": [
         "[vergoeding studieverlof]"
       ],
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=22&z=2019-04-01&g=2019-04-01",
           "validFrom": "01-04-2019",
           "validTo": "31-12-2019",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=22&z=2019-04-01&g=2019-04-01",
           "citation": "Art. 21 Slb  \r\nArt. 22 Slb",
-          "text": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulieren op de website van de Dienst Uitvoering Onderwijs.}"
+          "text": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulieren op de website van de Dienst Uitvoering Onderwijs.}",
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -871,17 +909,19 @@
       "action": "[verstrekken]",
       "object": "[template voor aanvraagformulieren studiekosten]",
       "recipient": "[leraar]",
-      "preconditions": "",
+      "preconditions": "[]",
       "create": [
         "[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]"
       ],
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=2",
           "validFrom": "01-04-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=2",
           "citation": "art. 7 lid 2 Slb",
-          "text": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulieren op de website van de Dienst Uitvoering Onderwijs.}"
+          "text": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulieren op de website van de Dienst Uitvoering Onderwijs.}",
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -892,17 +932,19 @@
       "action": "[verstrekken]",
       "object": "[template voor aanvraagformulieren studieverlof]",
       "recipient": "[leraar]",
-      "preconditions": "",
+      "preconditions": "[]",
       "create": [
         "[aanvraagformulieren studieverlof op de website van de Dienst Uitvoering Onderwijs]"
       ],
       "terminate": [],
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=2",
           "validFrom": "01-04-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=2",
           "citation": "art. 8 lid 2 Slb",
-          "text": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulieren op de website van de Dienst Uitvoering Onderwijs.}"
+          "text": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulieren op de website van de Dienst Uitvoering Onderwijs.}",
+          "explanation": ""
         }
       ],
       "explanation": ""
@@ -911,12 +953,13 @@
   "facts": [
     {
       "fact": "[Regering]",
+      "explanation": "als fact benoemd omdat Regering op enkele plaatsen als interested party benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd omdat Regering op enkele plaatsen als interested party benoemd is"
+      "sources": []
     },
     {
       "fact": "[bestuursorgaan]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -933,14 +976,11 @@
           }
         ]
       },
-      "version": "10-[20110223]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:1&lid=1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Onder bestuursorgaan wordt verstaan:  \r\na. een orgaan van een rechtspersoon die krachtens publiekrecht is ingesteld, of  \r\nb. een ander persoon of college, met enig openbaar gezag bekleed.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[orgaan van een rechtspersoon die krachtens publiekrecht is ingesteld]",
+      "explanation": "",
       "function": {
         "expression": "AND",
         "operands": [
@@ -948,14 +988,11 @@
           "[rechtspersoon die krachtens publiekrecht is ingesteld]"
         ]
       },
-      "version": "10-[20110223]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:1&lid=1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Onder bestuursorgaan wordt verstaan:  \r\na. een orgaan van een rechtspersoon die krachtens publiekrecht is ingesteld, of  \r\nb. een ander persoon of college, met enig openbaar gezag bekleed.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[persoon of college, met enig openbaar gezag bekleed]",
+      "explanation": "",
       "function": {
         "expression": "AND",
         "operands": [
@@ -969,20 +1006,17 @@
           "[met enig openbaar gezag bekleed]"
         ]
       },
-      "version": "10-[20110223]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:1&lid=1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Onder bestuursorgaan wordt verstaan:  \r\na. een orgaan van een rechtspersoon die krachtens publiekrecht is ingesteld, of  \r\nb. een ander persoon of college, met enig openbaar gezag bekleed.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[college]",
+      "explanation": "als fact benoemd omndat dit bij fact persoon of college als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd omndat dit bij fact persoon of college als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[organen, personen en colleges die niet als bestuursorgaan worden aangemerkt]",
+      "explanation": "Functio aangepast qua layout (met alt-enter) gewerkt, omdat de wetgeving is aangepast. Als je hier met opsomming werkt, zie je dat ook eerder. Wijziging is verwijzing naar nieuwe  wetgeving",
       "function": {
         "expression": "OR",
         "operands": [
@@ -997,106 +1031,104 @@
           "[de toetsingscommissie inzet bevoegdheden, bedoeld in artikel 32 van de Wet op de inlichtingen- en veiligheidsdiensten 2017]"
         ]
       },
-      "version": "10-[20110223]-[jjjjmmdd]",
-      "art": "art. 1:1 lid 2 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:1&lid=2&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{2.\tDe volgende organen, personen en colleges worden niet als bestuursorgaan aangemerkt:\r\na.\tde wetgevende macht;\r\nb.\tde kamers en de verenigde vergadering der Staten-Generaal;\r\nc.\tonafhankelijke, bij de wet ingestelde organen die met rechtspraak zijn belast, alsmede de Raad voor de rechtspraak en het College van afgevaardigden;\r\nd.\tde Raad van State en zijn afdelingen;\r\ne.\tde Algemene Rekenkamer;\r\nf.\tde Nationale ombudsman en de substituut-ombudsmannen als bedoeld in artikel 9, eerste lid, van de Wet Nationale ombudsman, en ombudsmannen en ombudscommissies als bedoeld in artikel 9:17, onderdeel b;\r\ng.\tde voorzitters, leden, griffiers en secretarissen van de in de onderdelen b tot en met f bedoelde organen, de procureur-generaal, de plaatsvervangend procureur-generaal en de advocaten-generaal bij de Hoge Raad, de besturen van de in onderdeel c bedoelde organen alsmede de voorzitters van die besturen, alsmede de commissies uit het midden van de in de onderdelen b tot en met f bedoelde organen;\r\nh.\tde commissie van toezicht op de inlichtingen- en veiligheidsdiensten en haar afdelingen, bedoeld in artikel 97 van de Wet op de inlichtingen- en veiligheidsdiensten 2017;\r\ni.\tde toetsingscommissie inzet bevoegdheden, bedoeld in artikel 32 van de Wet op de inlichtingen- en veiligheidsdiensten 2017.}",
-      "explanation": "Functio aangepast qua layout (met alt-enter) gewerkt, omdat de wetgeving is aangepast. Als je hier met opsomming werkt, zie je dat ook eerder. Wijziging is verwijzing naar nieuwe  wetgeving"
+      "sources": []
     },
     {
       "fact": "[wetgevende macht]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[de kamers en de verenigde vergadering der Staten-Generaal]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[onafhankelijke, bij de wet ingestelde organen die met rechtspraak zijn belast, alsmede de Raad voor de rechtspraak en het College van afgevaardigden]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[Raad van State en zijn afdelingen]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[Algemene Rekenkamer]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[Nationale ombudsman en de substituut-ombudsmannen als bedoeld in artikel 9, eerste lid, van de Wet Nationale ombudsman, en ombudsmannen en ombudscommissies als bedoeld in artikel 9:17, onderdeel b]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[voorzitters, leden, griffiers en secretarissen van de in de onderdelen b tot en met f bedoelde organen, de procureur-generaal, de plaatsvervangend procureur-generaal en de advocaten-generaal bij de Hoge Raad, de besturen van de in onderdeel c bedoelde organen alsmede de voorzitters van die besturen, alsmede de commissies uit het midden van de in de onderdelen b tot en met f bedoelde organen]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[commissie van toezicht betreffende de inlichtingen- en veiligheidsdiensten, bedoeld in artikel 97 van de Wet op de inlichtingen- en veiligheidsdiensten 2017]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[de toetsingscommissie inzet bevoegdheden, bedoeld in artikel 32 van de Wet op de inlichtingen- en veiligheidsdiensten 2017]",
+      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit bij fact organen, personen en colleges als operands benoemd is"
+      "sources": []
     },
     {
       "fact": "[belanghebbende]",
+      "explanation": "",
       "function": "[persoon wiens belang rechtstreeks bij een besluit is betrokken]",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "art": "art. 1:2 lid 1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:2&lid=1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Onder belanghebbende wordt verstaan: degene wiens belang rechtstreeks bij een besluit is betrokken}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[persoon wiens belang rechtstreeks bij een besluit is betrokken]",
+      "explanation": "",
       "function": "[]",
-      "sources": [],
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[besluit]",
+      "explanation": "",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "2-[19980101]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=1&z=2017-03-01&g=2017-03-01",
-      "sourcetext": "{Onder besluit wordt verstaan: een schriftelijke beslissing van een bestuursorgaan, inhoudende een publiekrechtelijke rechtshandeling.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[verstrekte gegevens en bescheiden zijn onvoldoende voor de beoordeling van de aanvraag of voor de voorbereiding van de beschikking]",
+      "explanation": "",
       "function": "[]",
-      "sources": [],
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[besluit tot niet in behandeling nemen aanvraag]",
+      "explanation": "",
       "function": "[]",
-      "sources": [],
-      "explanation": ""
+      "sources": []
+    },
+    {
+      "fact": "[besluit dat van algemene strekking is]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
     },
     {
       "fact": "[beschikking]",
+      "explanation": "De passage \"met inbegrip van de afwijzing van een aanvraag daarvan\" is niet in de interpretatie opgenomen. Het is niet duidelijk wat deze passage toevoegd aan de interpretatie. Als het nodig het afwijzen expliciet te benoemen, dan is het bij het definiÃ«ren van het concept [besluit].",
       "function": {
         "expression": "AND",
         "operands": [
@@ -1107,68 +1139,53 @@
           }
         ]
       },
-      "version": "2-[19980101]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 2 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=2&z=2017-03-01&g=2017-03-01",
-      "sourcetext": "{Onder beschikking wordt verstaan: een besluit dat niet van algemene strekking is, met inbegrip van de afwijzing van een aanvraag daarvan.}",
-      "explanation": "De passage \"met inbegrip van de afwijzing van een aanvraag daarvan\" is niet in de interpretatie opgenomen. Het is niet duidelijk wat deze passage toevoegd aan de interpretatie. Als het nodig het afwijzen expliciet te benoemen, dan is het bij het definiÃ«ren van het concept [besluit]."
+      "sources": []
     },
     {
       "fact": "[besluit treedt in werking]",
+      "explanation": "Toegevoegd, om fact besluit treedt in werking te definiëren",
       "function": "[]",
-      "version": "",
-      "art": "art. 3:40 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.6&artikel=3:40",
-      "sourcetext": "Een besluit treedt niet in werking voordat het is bekendgemaakt.",
-      "explanation": "Toegevoegd, om fact besluit treedt in werking te definiëren"
+      "sources": []
     },
     {
       "fact": "[verzoek een besluit te nemen]",
+      "explanation": "Dit concept beschrijft het verzoek voordat het is ingediend bij een bestuursorgaan.",
       "function": "[]",
-      "version": "2-[19980101]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 3 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",
-      "sourcetext": "{Onder aanvraag wordt verstaan: een verzoek van een belanghebbende, een besluit te nemen.}",
-      "explanation": "Dit concept beschrijft het verzoek voordat het is ingediend bij een bestuursorgaan."
+      "sources": []
     },
     {
       "fact": "[formulier]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "artikel 4:4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4",
-      "sourcetext": "{Het bestuursorgaan dat bevoegd is op de aanvraag te beslissen, kan voor het indienen van aanvragen en het verstrekken van gegevens een formulier vaststellen, voor zover daarin niet is voorzien bij wettelijk voorschrift.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[formulier voor het verstrekken van gegevens]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "artikel 4:4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4",
-      "sourcetext": "{Het bestuursorgaan dat bevoegd is op de aanvraag te beslissen, kan voor het indienen van aanvragen en het verstrekken van gegevens een formulier vaststellen, voor zover daarin niet is voorzien bij wettelijk voorschrift.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[de aanvraag is binnen de afgelopen 4 weken aangevuld]",
+      "explanation": "Toegevoegd, omdat buitenbehandelingstelling aan een termijn is verbonden",
       "function": "[]",
-      "version": "",
-      "art": "art.4:5, lid 4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=4",
-      "sourcetext": "{Een besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken.}",
-      "explanation": "Toegevoegd, omdat buitenbehandelingstelling aan een termijn is verbonden"
+      "sources": []
     },
     {
       "fact": "[gestelde termijn voor aanvulling is ongebruikt verstreken]",
+      "explanation": "Toegevoegd, omdat buitenbehandelingstelling aan een termijn is verbonden",
       "function": "[]",
-      "version": "",
-      "art": "art.4:5, lid 4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=4",
-      "sourcetext": "{Een besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken.}",
-      "explanation": "Toegevoegd, omdat buitenbehandelingstelling aan een termijn is verbonden"
+      "sources": []
+    },
+    {
+      "fact": "[algemeen verbindend voorschrift, omtrent de afweging van belangen, de vaststelling van feiten of de uitleg van wettelijke voorschriften bij het gebruik van een bevoegdheid van een bestuursorgaan]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
     },
     {
       "fact": "[beleidsregel]",
+      "explanation": "",
       "function": {
         "expression": "AND",
         "operands": [
@@ -1179,405 +1196,321 @@
           }
         ]
       },
-      "version": "2-[19980101]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=4&z=2017-03-01&g=2017-03-01",
-      "sourcetext": "{Onder beleidsregel wordt verstaan: een bij besluit vastgestelde algemene regel, niet zijnde een algemeen verbindend voorschrift, omtrent de afweging van belangen, de vaststelling van feiten of de uitleg van wettelijke voorschriften bij het gebruik van een bevoegdheid van een bestuursorgaan.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aanvraag]",
+      "explanation": "",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": [
+          "[leraar]"
+        ]
       },
-      "version": "2-[19980101]-[jjjjmmdd]",
-      "art": "art. 1:3 lid 1 en 3 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01",
-      "sourcetext": "{Onder aanvraag wordt verstaan: een verzoek van een belanghebbende, een besluit te nemen.}  \r\n(â€¦)  \r\n{Onder besluit wordt verstaan: een schriftelijke beslissing van een bestuursorgaan, inhoudende een publiekrechtelijke rechtshandeling.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[bij besluit vastgestelde algemene regel]",
+      "explanation": "",
       "function": "[]",
-      "sources": [],
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aanvraag subsidieverlening]",
+      "explanation": "",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art. 4:35 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35",
-      "sourcetext": "{1 De subsidieverlening kan in ieder geval worden geweigerd indien een gegronde reden bestaat om aan te nemen dat:\r\n\r\na. de activiteiten niet of niet geheel zullen plaatsvinden;\r\n\r\nb. de aanvrager niet zal voldoen aan de aan de subsidie verbonden verplichtingen;\r\n\r\nc. de aanvrager niet op een behoorlijke wijze rekening en verantwoording zal afleggen omtrent de verrichte activiteiten en de daaraan verbonden uitgaven en inkomsten, voor zover deze voor de vaststelling van de subsidie van belang zijn.\r\n\r\n2 De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager:\r\n\r\na. in het kader van de aanvraag onjuiste of onvolledige gegevens heeft verstrekt en de verstrekking van deze gegevens tot een onjuiste beschikking op de aanvraag zou hebben geleid, of\r\n\r\nb. failliet is verklaard of aan hem surséance van betaling is verleend of ten aanzien van hem de schuldsaneringsregeling natuurlijke personen van toepassing is verklaard, dan wel een verzoek daartoe bij de rechtbank is ingediend.\r\n\r\n3 De subsidieverlening wordt voorts geweigerd indien de verstrekking van subsidie naar het oordeel van het bestuursorgaan niet verenigbaar is met het bepaalde in de artikelen 107 en 108 van het Verdrag betreffende de werking van de Europese Unie.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aanvraag subsidie voor studiekosten]",
+      "explanation": "",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art. 7 lid 1 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=1",
-      "sourcetext": "{De subsidie voor studiekosten wordt aangevraagd door de leraar.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aanvraag subsidie voor studieverlof]",
+      "explanation": "",
       "function": {
         "expression": "CREATE",
         "operands": [
           "[ingevuld aanvraagformulier studieverlof op de website van de Dienst Uitvoering Onderwijs]"
         ]
       },
-      "version": "",
-      "art": "art. 8 lid 1 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=1",
-      "sourcetext": "{De subsidie voor studieverlof wordt door de leraar aangevraagd voor het bevoegd gezag.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]",
+      "explanation": "Pim en ik gaan aanvraagformulieren voor studiekosten en studieverlof als 1 modelleren. Vandaar in deze regel ook 1 'aanvraagformulieren Nog even bewust niets gedaan met source tekst enz.",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art. 7 lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=7&lid=2",
-      "sourcetext": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulierenopde website van de Dienst Uitvoering Onderwijs.}",
-      "explanation": "Pim en ik gaan aanvraagformulieren voor studiekosten en studieverlof als 1 modelleren. Vandaar in deze regel ook 1 'aanvraagformulieren Nog even bewust niets gedaan met source tekst enz."
+      "sources": []
     },
     {
       "fact": "[template voor aanvraagformulieren studiekosten]",
+      "explanation": "Als fact benoemd omdat dit een object bij aanvraagformulieren verstrekken is",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd omdat dit een object bij aanvraagformulieren verstrekken is"
+      "sources": []
     },
     {
       "fact": "[template voor aanvraagformulieren studieverlof]",
+      "explanation": "Als fact benoemd omdat dit een object bij aanvraagformulieren verstrellen is",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd omdat dit een object bij aanvraagformulieren verstrellen is"
+      "sources": []
     },
     {
       "fact": "[aanvraagformulieren studieverlof op de website van de Dienst Uitvoering Onderwijs]",
+      "explanation": "Pim en ik gaan aanvraagformulieren voor studiekosten en studieverlof als 1 modelleren. Vandaar in deze regel ook 1 'aanvraagformulieren Nog even bewust niets gedaan met source tekst enz.",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art. 8 lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=2",
-      "sourcetext": "{De aanvraag geschiedt door invulling en inlevering of elektronische verzending van daartoe bestemde door de minister te verstrekken formulierenopde website van de Dienst Uitvoering Onderwijs.}",
-      "explanation": "Pim en ik gaan aanvraagformulieren voor studiekosten en studieverlof als 1 modelleren. Vandaar in deze regel ook 1 'aanvraagformulieren Nog even bewust niets gedaan met source tekst enz."
+      "sources": []
     },
     {
       "fact": "[aanvrager]",
+      "explanation": "Toegevoegd, want miste in de excel. Onderwerp van gesprek of dit de juiste term moet zijn. Heb een issue aangemaakt.",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, want miste in de excel. Onderwerp van gesprek of dit de juiste term moet zijn. Heb een issue aangemaakt."
+      "sources": []
     },
     {
       "fact": "[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]",
+      "explanation": "Fact toegevoegd, omdat dit een warning gaf",
       "function": "[]",
-      "version": "",
-      "art": "art 9 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=9",
-      "sourcetext": "{Subsidieaanvragen kunnen jaarlijks worden ingediend van 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd.}",
-      "explanation": "Fact toegevoegd, omdat dit een warning gaf"
+      "sources": []
     },
     {
       "fact": "[subsidieontvanger studiekosten]",
+      "explanation": "Toegevoegd, want miste in de excel. Toch keuze om ontvanger wel te splitsen in studiekosten en studeverlof, omdat de bedragen een andere interested party kunnen hebben. Subsidieontvanger na overleg met Pim weer toegevoegd, incl reference en soucetekst",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art. 3 lid 1 onder a Sbl",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
-      "sourcetext": "{De minister kan subsidie verstrekken aan a. de leraar voor studiekosten in verband met het volgen van een opleiding}",
-      "explanation": "Toegevoegd, want miste in de excel. Toch keuze om ontvanger wel te splitsen in studiekosten en studeverlof, omdat de bedragen een andere interested party kunnen hebben. Subsidieontvanger na overleg met Pim weer toegevoegd, incl reference en soucetekst"
+      "sources": []
     },
     {
       "fact": "[subsidieontvanger studieverlof]",
+      "explanation": "Toegevoegd, want miste in de excel. Toch keuze om ontvanger wel te splitsen in studiekosten en studeverlof, omdat de bedragen een andere interested party kunnen hebben. Subsidieontvanger na overleg met Pim weer toegevoegd, incl reference en soucetekst",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 1 onder b Sbl",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
-      "sourcetext": "{De minister kan subsidie verstrekken aan b. het bevoegd gezag voor kosten in verband met het verlenen van studieverlof aan de leraar.",
-      "explanation": "Toegevoegd, want miste in de excel. Toch keuze om ontvanger wel te splitsen in studiekosten en studeverlof, omdat de bedragen een andere interested party kunnen hebben. Subsidieontvanger na overleg met Pim weer toegevoegd, incl reference en soucetekst"
+      "sources": []
     },
     {
       "fact": "[formulier voor het indienen van aanvragen en het verstrekken van gegevens is vastgesteld door bestuursorgaan]",
+      "explanation": "",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "art": "art. 4:4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4&z=2017-03-01&g=2017-03-01",
-      "sourcetext": "{Het bestuursorgaan dat bevoegd is op de aanvraag te beslissen, kan voor het indienen van aanvragen en het verstrekken van gegevens een formulier vaststellen, voor zover daarin niet is voorzien bij wettelijk voorschrift.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]",
+      "explanation": "Toevoegd, omdat dit fact nog niet als fact was opgenomen",
       "function": "[]",
-      "version": "",
-      "art": "art. 4:4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4",
-      "sourcetext": "{Het bestuursorgaan dat bevoegd is op de aanvraag te beslissen, kan voor het indienen van aanvragen en het verstrekken van gegevens een formulier vaststellen, voor zover daarin niet is voorzien bij wettelijk voorschrift.}",
-      "explanation": "Toevoegd, omdat dit fact nog niet als fact was opgenomen"
+      "sources": []
     },
     {
       "fact": "[ingevuld aanvraagformulier studieverlof op de website van de Dienst Uitvoering Onderwijs]",
+      "explanation": "Fact toegevoegd, omdat dit fact nog niet als fact was opgenomen en het een warning gaf",
       "function": "[]",
-      "version": "1-[19980101]-[jjjjmmdd]",
-      "art": "art. 4:4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4",
-      "sourcetext": "{Het bestuursorgaan dat bevoegd is op de aanvraag te beslissen, kan voor het indienen van aanvragen en het verstrekken van gegevens een formulier vaststellen, voor zover daarin niet is voorzien bij wettelijk voorschrift.}",
-      "explanation": "Fact toegevoegd, omdat dit fact nog niet als fact was opgenomen en het een warning gaf"
+      "sources": []
     },
     {
       "fact": "[besluit berust op deugdelijke motivering]",
+      "explanation": "",
       "function": "[]",
-      "version": "1-[19980101]-[jjjjmmdd]",
-      "art": "art. 3:46 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.7&artikel=3:46&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Een besluit dient te berusten op een deugdelijke motivering.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[nadelige gevolgen van een besluit zijn onevenredig in verhouding tot de met het besluit te dienen doelen]",
+      "explanation": "Hetgeen nu in de fact staat, is een situatie die volgens art. 3:4 lid 2 niet voor mag komen. Waarom is dit dan nu wel een fact?",
       "function": "[]",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "art": "art. 3:4 lid 2 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.2&artikel=3:4&lid=2",
-      "sourcetext": "De voor een of meer belanghebbenden nadelige gevolgen van een besluit mogen niet onevenredig zijn in verhouding tot de met het besluit te dienen doelen.",
-      "explanation": "Hetgeen nu in de fact staat, is een situatie die volgens art. 3:4 lid 2 niet voor mag komen. Waarom is dit dan nu wel een fact?"
+      "sources": []
     },
     {
       "fact": "[aanvraag geheel of gedeeltelijk is geweigerd op grond van artikel 2:15 Awb]",
+      "explanation": "",
       "function": "[]",
-      "version": "3-[20040701]-[jjjjmmdd]",
-      "art": "art. 4:5 lid 1, onder b, Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=1",
-      "sourcetext": "{b. de aanvraag geheel of gedeeltelijk is geweigerd op grond van artikel 2:15, of}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aanvrager heeft de gelegenheid gehad de aanvraag aan te vullen]",
+      "explanation": "",
       "function": "[]",
-      "version": "3-[20040701]-[jjjjmmdd]",
-      "art": "art. 4:5 lid 1, slot, Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=1",
-      "sourcetext": "{mits de aanvrager de gelegenheid heeft gehad de aanvraag binnen een door het bestuursorgaan gestelde termijn aan te vullen.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aanvrager heeft voldaan aan enig wettelijk voorschrift voor het in behandeling nemen van de aanvraag]",
+      "explanation": "",
       "function": "[]",
-      "version": "3-[20040701]-[jjjjmmdd]",
-      "art": "art. 4:5 lid 1, onder a, Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=1",
-      "sourcetext": "{Het bestuursorgaan kan besluiten de aanvraag niet te behandelen, indien:  \r\na. de aanvrager niet heeft voldaan aan enig wettelijk voorschrift voor het in behandeling nemen van de aanvraag, of}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken]",
+      "explanation": "",
       "function": "[]",
-      "version": "3-[20040701]-[jjjjmmdd]",
-      "art": "art. 4:5 lid 4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=4",
-      "sourcetext": "{Een besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[bestuursorgaan is bevoegd op de aanvraag te beslissen]",
+      "explanation": "Is artikel 1:3, eerste lid Awb niet hier ook relevant? Onder besluit wordt verstaan: een schriftelijke beslissing van een bestuursorgaan, inhoudende een publiekrechtelijke rechtshandeling.",
       "function": "[]",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "art": "art. 4:1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Tenzij bij wettelijk voorschrift anders is bepaald, wordt de aanvraag tot het geven van een beschikking schriftelijk ingediend bij het bestuursorgaan dat bevoegd is op de aanvraag te beslissen.}",
-      "explanation": "Is artikel 1:3, eerste lid Awb niet hier ook relevant? Onder besluit wordt verstaan: een schriftelijke beslissing van een bestuursorgaan, inhoudende een publiekrechtelijke rechtshandeling."
+      "sources": []
     },
     {
       "fact": "[bij wettelijk voorschrift is anders bepaald]",
+      "explanation": "",
       "function": "[]",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "art": "art. 4:1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Tenzij bij wettelijk voorschrift anders is bepaald, wordt de aanvraag tot het geven van een beschikking schriftelijk ingediend bij het bestuursorgaan dat bevoegd is op de aanvraag te beslissen.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[formulier is bij wettelijk voorschrift voorzien]",
+      "explanation": "",
       "function": "[]",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "art": "art. 4:4 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:4&z=2017-03-01&g=2017-03-01",
-      "sourcetext": "{Het bestuursorgaan dat bevoegd is op de aanvraag te beslissen, kan voor het indienen van aanvragen en het verstrekken van gegevens een formulier vaststellen, voor zover daarin niet is voorzien bij wettelijk voorschrift.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[besluit tot weigeren subsidie]",
+      "explanation": "als fact opgenomen omdat dit bij de act bestuursorgaan weigert subsidieverlening aan belanghebbende bij create als fact benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact opgenomen omdat dit bij de act bestuursorgaan weigert subsidieverlening aan belanghebbende bij create als fact benoemd is"
+      "sources": []
     },
     {
       "fact": "[subsidie aangevraagd door leraar voor bevoegd gezag]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 8 lid 1 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=8&lid=1",
-      "sourcetext": "{De subsidie voor studieverlof wordt door de leraar aangevraagd voor het bevoegd gezag.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[subsidieaanvraag is ingediend van 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 9 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=9",
-      "sourcetext": "{Subsidieaanvragen kunnen jaarlijks worden ingediend van 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[leraar behaalt in de subsidieperiode minder dan vijftien studiepunten]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 13 lid 1 slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
-      "sourcetext": "{De minister kan de subsidie voor studiekosten terugvorderen indien de leraar in de subsidieperiode minder dan vijftien studiepunten behaalt.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[subsidie voor voor studiekosten in verband met het volgen van een opleiding]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 1 onder a. Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
-      "sourcetext": "{De minister kan subsidie verstrekken aan: a. de leraar voor studiekosten in verband met het volgen van een opleiding}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[subsidie voor kosten in verband met het verlenen van studieverlof aan de leraar]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 1 onder b. Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
-      "sourcetext": "{De minister kan subsidie verstrekken aan: b. het bevoegd gezag voor kosten in verband met het verlenen van studieverlof aan de leraar.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[de leraar is in dienst bij het bevoegd gezag]",
+      "explanation": "Fact toegevoegd, omdat dit een preconditie is bij de act verlenen subsidie studieverlof",
       "function": "[]",
-      "version": "",
-      "art": "art. 20, onder a Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=20",
-      "sourcetext": "{de leraar in dienst is bij het bevoegd gezag}",
-      "explanation": "Fact toegevoegd, omdat dit een preconditie is bij de act verlenen subsidie studieverlof"
+      "sources": []
     },
     {
       "fact": "[aan de leraar is subsidie voor studiekosten verleend tenzij voor een opleiding geen collegegeld verschuldigd is]",
+      "explanation": "Fact toegevoegd, omdat dit een preconditie is bij de act verlenen subsidie studieverlof",
       "function": "[]",
-      "version": "",
-      "art": "art. 20, onder b Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=20",
-      "sourcetext": "{aan deze leraar subsidie voor studiekosten is verleend tenzij voor een opleiding geen collegegeld verschuldigd is}",
-      "explanation": "Fact toegevoegd, omdat dit een preconditie is bij de act verlenen subsidie studieverlof"
+      "sources": []
     },
     {
       "fact": "[subsidie voor bacheloropleiding leraar]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=2",
-      "sourcetext": "{De subsidie kan worden verstrekt voor bachelor-, master- en deficiëntieopleidingen.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[subsidie voor masteropleiding leraar]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=2",
-      "sourcetext": "{De subsidie kan worden verstrekt voor bachelor-, master- en deficiëntieopleidingen.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[subsidie voor deficiëntieopleidingen leraar]",
+      "explanation": "Omdat ik niet wist wat een deficiëntie-opleiding is: Heb je een havo-, vwo- of een 'oud' mbo-lang-diploma waarmee je niet toelaatbaar bent omdat één of meer verplichte eindexamenvakken ontbreken? Dan heb je (een) deficiëntie(s). Deze deficiëntie(s) moet je opheffen vóórdat je met de opleiding start.  Bron: https:\/\/www.hogeschoolrotterdam.nl\/voorlichting\/toelatingsvoorwaarden\/deficienties\/ \r\nIn artikel 1 van de regeling wordt deficiëntie-opleiding gedefiniteerd",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=2",
-      "sourcetext": "{De subsidie kan worden verstrekt voor bachelor-, master- en deficiëntieopleidingen.}",
-      "explanation": "Omdat ik niet wist wat een deficiëntie-opleiding is: Heb je een havo-, vwo- of een 'oud' mbo-lang-diploma waarmee je niet toelaatbaar bent omdat één of meer verplichte eindexamenvakken ontbreken? Dan heb je (een) deficiëntie(s). Deze deficiëntie(s) moet je opheffen vóórdat je met de opleiding start.  Bron: https://www.hogeschoolrotterdam.nl/voorlichting/toelatingsvoorwaarden/deficienties/ \r\nIn artikel 1 van de regeling wordt deficiëntie-opleiding gedefiniteerd"
+      "sources": []
     },
     {
       "fact": "[subsidie voor studiekosten]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 1, onder a Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
-      "sourcetext": "{De minister kan subsidie verstrekken aan: a. de leraar voor studiekosten in verband met het volgen van een opleiding.}",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[subsidie voor studieverlof]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 1, onder b Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=1",
-      "sourcetext": "{De minister kan subsidie verstrekken aan: b. het bevoegd gezag voor kosten in verband met het verlenen van studieverlof aan de leraar..}",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 3 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=3",
-      "sourcetext": "{De subsidie wordt verstrekt voor één studiejaar en voor één opleiding.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[vergoeding kosten collegegeld]",
+      "explanation": "MIN ([verschuldigde collegegeld], [maximaal 7.000] Moet nog gedaan worden",
       "function": "[]",
-      "version": "",
-      "art": "art. 15, onder a, Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=15",
-      "sourcetext": "{De subsidie voor studiekosten bedraagt de som van een vergoeding voor: a. de kosten van collegegeld tot een maximum van € 7000;}",
-      "explanation": "MIN ([verschuldigde collegegeld], [maximaal 7.000] Moet nog gedaan worden"
+      "sources": []
     },
     {
       "fact": "[vergoeding studiemiddelen]",
+      "explanation": "MIN (PRODUCT ([10%],[verschuldigde collegegeld]), [â\u201A¬ 350]) Moet nog gedaan worden",
       "function": "[]",
-      "version": "",
-      "art": "art. 15, onder b, Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=15",
-      "sourcetext": "{De subsidie voor studiekosten bedraagt de som van een vergoeding voor: b. de kosten van studiemiddelen van tien procent van het verschuldigde collegegeld tot een maximum van € 350}",
-      "explanation": "MIN (PRODUCT ([10%],[verschuldigde collegegeld]), [â‚¬ 350]) Moet nog gedaan worden"
+      "sources": []
     },
     {
       "fact": "[vergoeding reiskosten]",
+      "explanation": "MIN (PRODUCT ([verschuldigde collegegeld], [10%)], [â\u201A¬ 350]) Moet nog gedaan worden",
       "function": "[]",
-      "version": "",
-      "art": "art. 15, onder c, Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=15",
-      "sourcetext": "{De subsidie voor studiekosten bedraagt de som van een vergoeding voor: c. reiskosten van tien procent van het verschuldigde collegegeld tot een maximum van € 350.}",
-      "explanation": "MIN (PRODUCT ([verschuldigde collegegeld], [10%)], [â‚¬ 350]) Moet nog gedaan worden"
+      "sources": []
     },
     {
       "fact": "[vergoeding studieverlof]",
+      "explanation": "berekening voor [aantal uur] x [bedrag per uur] met varianten voor:\r\n- voltijd- en deeltijdaanstelling;\r\n- bachelor en master;\r\n- basisonderwijs, voortgezet onderwijs, beroepsonderwijs, hoger beroepsonderwijs \r\n\r\nDit moet nog gedaan worden",
       "function": "[]",
-      "version": "",
-      "art": "art. 21 en 22 Slb",
-      "juriconnect": "",
-      "sourcetext": "Voor subsidiëring komt per jaar voor een voltijdsaanstelling, of voor een deeltijdsaanstelling een evenredig deel, ten hoogste het volgende aantal studieverlofuren in aanmerking:\r\na. voor een bacheloropleiding: 160 uur; en\r\nb. voor een masteropleiding voor een subsidieontvanger in de sector:\r\n1. basisonderwijs: 320 uur;\r\n2. speciaal onderwijs of voortgezet speciaal onderwijs: 320 uur;\r\n3. voortgezet onderwijs: 240 uur;\r\n4. beroepsonderwijs en educatie: 240 uur; en\r\n5. hoger beroepsonderwijs: 320 uur.\r\n\r\nDe subsidiebedragen voor een studieverlofuur zijn voor een subsidieontvanger in de sector:\r\na. basisonderwijs: â‚¬ 37,79;\r\nb. speciaal onderwijs of voortgezet speciaal onderwijs: â‚¬ 39,58;\r\nc. voortgezet onderwijs: â‚¬ 42,86;\r\nd. beroepsonderwijs en educatie: â‚¬ 44,07; en\r\ne. hoger beroepsonderwijs: â‚¬ 48,00.",
-      "explanation": "berekening voor [aantal uur] x [bedrag per uur] met varianten voor:\r\n- voltijd- en deeltijdaanstelling;\r\n- bachelor en master;\r\n- basisonderwijs, voortgezet onderwijs, beroepsonderwijs, hoger beroepsonderwijs \r\n\r\nDit moet nog gedaan worden"
+      "sources": []
+    },
+    {
+      "fact": "[leraar is aangesteld als ambulant begeleider]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[leraar is aangesteld als zorgcoördinator]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[leraar is aangesteld als intern begeleider]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[leraar is aangesteld als remedial teacher]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
     },
     {
       "fact": "[leraar voldoet aan de subsidiecriteria]",
+      "explanation": "Wat betekent werkt, of werkte in de twaalf maanden voorafgaand aan de subsidieaanvraag. Betekent dat , dat de leraar op het moment van de subsidieaanvraag niet meer bij de werkgever hoeft te werken. En zo ja, hoe lang geleden mag het dan zijn dat de leraar twaalf maanden in het onderwijs heeft gewerkt? \r\nEr is geen art 20, lid 1. Er is artikel 20, sub a en b Slb. En je moet aan beide vereisten voldoen, dus volstaat hier, naar mijn mening,  een verwijzing naar het gehele artikel 20 Slb., zonder nadere aanduiding.",
       "function": {
         "expression": "AND",
         "operands": [
@@ -1611,321 +1544,251 @@
           "[leraar die ingeschreven staat in registerleraar.nl]"
         ]
       },
-      "version": "",
-      "art": "art. 14 Slb",
-      "juriconnect": "",
-      "sourcetext": "",
-      "explanation": "Wat betekent werkt, of werkte in de twaalf maanden voorafgaand aan de subsidieaanvraag. Betekent dat , dat de leraar op het moment van de subsidieaanvraag niet meer bij de werkgever hoeft te werken. En zo ja, hoe lang geleden mag het dan zijn dat de leraar twaalf maanden in het onderwijs heeft gewerkt? \r\nEr is geen art 20, lid 1. Er is artikel 20, sub a en b Slb. En je moet aan beide vereisten voldoen, dus volstaat hier, naar mijn mening,  een verwijzing naar het gehele artikel 20 Slb., zonder nadere aanduiding."
+      "sources": []
     },
     {
       "fact": "[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]",
+      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]",
+      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[leraar werkt bij een of meer bekostigde onderwijsinstellingen]",
+      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[leraar werkt in een of meer orthopedagogisch-didactische centra]",
+      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]",
+      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]",
+      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[leraar die ingeschreven staat in registerleraar.nl]",
+      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in fact leraar voldoet aan subsidiecriteria dit als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[uitzondering waarbij subsidie wordt verstrekt voor tweede opleiding]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 4 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=4",
-      "sourcetext": "{n afwijking van het derde lid kan subsidie worden verstrekt voor een tweede opleiding indien:\r\na. subsidie wordt aangevraagd voor een masteropleiding en reeds subsidie is ontvangen voor een bacheloropleiding;\r\nb. subsidie wordt aangevraagd voor een masteropleiding en reeds subsidie is ontvangen voor een deficiëntieopleiding, met dien verstande dat indien reeds subsidie voor het volgen van een deficiëntieopleiding is verleend, voor een opleiding van meer dan 60 studiepunten ten hoogste twee maal subsidie wordt verleend; en\r\nc. subsidie is ontvangen op basis van deRegeling lerarenbeurs voor scholing, zij-instroom en bewegingsonderwijs 2009–2017zoals deze gold vóór 1 april 2013 voor een opleiding anders dan een deficiëntie-, bachelor- of masteropleiding.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[opleiding met studielast van 60 studiepunten waarvoor ten hoogste twee maal subsidie wordt verstrekt]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 6 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=6",
-      "sourcetext": "{Voor een opleiding met een studielast van zestig studiepunten wordt ten hoogste twee maal subsidie verstrekt. Om voor de tweede subsidie in aanmerking te komen, dient deze binnen drie studiejaren na de eerste subsidieverlening te worden aangevraagd.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[opleiding met studielast van meer dan 60 studiepunten waarvoor ten hoogste drie maal subsidie wordt verstrekt]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 3 lid 7 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=3&lid=7",
-      "sourcetext": "{Voor een opleiding met een studielast van meer dan zestig studiepunten wordt ten hoogste drie maal subsidie verstrekt. Om voor de tweede of derde subsidie in aanmerking te komen, dient deze binnen vijf studiejaren na de eerste subsidieverlening te worden aangevraagd.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[leraar ontvangt van de minister een tegemoetkoming in de studiekosten voor het volgen van de opleiding]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 10 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=10",
-      "sourcetext": "{Onverminderd artikel 4:35 van de Algemene wet bestuursrecht weigert de minister subsidieverlening aan een leraar, indien deze van de minister een tegemoetkoming in de studiekosten ontvangt voor het volgen van de opleiding.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 6 lid 1 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=6&lid=1",
-      "sourcetext": "{Onverminderd het tweede lid verdeelt de minister het beschikbare bedrag per doelgroep, in volgorde van ontvangst van de aanvragen voor subsidie met dien verstande dat aan aanvragers aan wie op basis van deze regeling reeds voor een eerste of tweede maal subsidie is verleend voor dezelfde opleiding, voorrang wordt verleend bij subsidieverstrekking.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[beschikbare bedrag voor de subsidieregeling lerarenbeurs]",
+      "explanation": "Als fact toegevoegd omdat dit bij act Minister OCW verdeelt beschikbare bedrag voor subsidieregeling lerarenbeurs per doelgroep als object benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact toegevoegd omdat dit bij act Minister OCW verdeelt beschikbare bedrag voor subsidieregeling lerarenbeurs per doelgroep als object benoemd is"
+      "sources": []
     },
     {
       "fact": "[concrete verdeling van het beschikbare budget in een studiejaar per soort onderwijs]",
+      "explanation": "In deze afleiding is het een beetje schipperen tussen letterlijk opnemen van bronteksten en het maken van een helder gestructureerde interpretatie\r\nWijziging: Concrete verdeling van het beschikbare budget in een studiejaar per soort onderwijs. Originele tekst van fact: budget volledig benut\r\nartikel 6, vierde lid Slb:\r\nDe verdeling van het beschikbare bedrag voor het studiejaar 2018\u20132019 over de verschillende doelgroepen geschiedt als volgt: \r\na. \u20AC 27.800.000 is beschikbaar voor opleidingen van leraren werkzaam in het basisonderwijs, het speciaal onderwijs en het voortgezet speciaal onderwijs;\r\n\r\n b. \u20AC 39.000.000 is beschikbaar voor opleidingen van leraren werkzaam in het voortgezet onderwijs;\r\n\r\n c. \u20AC 11.375.000 is beschikbaar voor opleidingen van leraren werkzaam in het beroepsonderwijs en educatie; en\r\n\r\n d. \u20AC 16.125.000 is beschikbaar voor opleidingen van leraren werkzaam in het hoger beroepsonderwijs.",
       "function": "[]",
-      "version": "",
-      "art": "art. 6 lid 4 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=6&lid=4",
-      "sourcetext": "{De verdeling van het beschikbare bedrag voor het studiejaar 2018–2019 over de verschillende doelgroepen geschiedt als volgt:\r\na. € 27.800.000 is beschikbaar voor opleidingen van leraren werkzaam in het basisonderwijs, het speciaal onderwijs en het voortgezet speciaal onderwijs;\r\nb. € 39.000.000 is beschikbaar voor opleidingen van leraren werkzaam in het voortgezet onderwijs;\r\nc. € 11.375.000 is beschikbaar voor opleidingen van leraren werkzaam in het beroepsonderwijs en educatie; en\r\nd. € 16.125.000 is beschikbaar voor opleidingen van leraren werkzaam in het hoger beroepsonderwijs.}",
-      "explanation": "In deze afleiding is het een beetje schipperen tussen letterlijk opnemen van bronteksten en het maken van een helder gestructureerde interpretatie\r\nWijziging: Concrete verdeling van het beschikbare budget in een studiejaar per soort onderwijs. Originele tekst van fact: budget volledig benut\r\nartikel 6, vierde lid Slb:\r\nDe verdeling van het beschikbare bedrag voor het studiejaar 2018–2019 over de verschillende doelgroepen geschiedt als volgt: \r\na. € 27.800.000 is beschikbaar voor opleidingen van leraren werkzaam in het basisonderwijs, het speciaal onderwijs en het voortgezet speciaal onderwijs;\r\n\r\n b. € 39.000.000 is beschikbaar voor opleidingen van leraren werkzaam in het voortgezet onderwijs;\r\n\r\n c. € 11.375.000 is beschikbaar voor opleidingen van leraren werkzaam in het beroepsonderwijs en educatie; en\r\n\r\n d. € 16.125.000 is beschikbaar voor opleidingen van leraren werkzaam in het hoger beroepsonderwijs."
+      "sources": []
     },
     {
       "fact": "[hoogte van de subsidie voor studiekosten]",
+      "explanation": "Fact benoemd omdat in act minister verdeelt het beschikbare bedrag benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "Fact benoemd omdat in act minister verdeelt het beschikbare bedrag benoemd is"
+      "sources": []
     },
     {
       "fact": "[hoogte van de subsidie voor studieverlof]",
+      "explanation": "Als fact benoemd omdat in act minister verdeelt het beschikbare bedrag benoemd is",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd omdat in act minister verdeelt het beschikbare bedrag benoemd is"
+      "sources": []
     },
     {
       "fact": "[budget volledig benut]",
+      "explanation": "Budget volledig benut toegevoegd. Deze wordt in de preconditie van minister verstrekt subsidie lerarenbeurs aan leraar gebruikt. Preconditie is negatief geformuleerd. Wat hier bedoeld wordt is dat er nog wel budget moet zijn. De minister stelt periodoek vast hoeveel budget hij per doelgroep beschikbaar stelt. Als dat geld op is, kan hij geen sbusdie meer verstrekken",
       "function": "[]",
-      "version": "",
-      "art": "art. 6, lid 1 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=6&lid=1",
-      "sourcetext": "{Onverminderd het tweede lid verdeelt de minister het beschikbare bedrag per doelgroep, in volgorde van ontvangst van de aanvragen voor subsidie met dien verstande dat aan aanvragers aan wie op basis van deze regeling reeds voor een eerste of tweede maal subsidie is verleend voor dezelfde opleiding, voorrang wordt verleend bij subsidieverstrekking.}",
-      "explanation": "Budget volledig benut toegevoegd. Deze wordt in de preconditie van minister verstrekt subsidie lerarenbeurs aan leraar gebruikt. Preconditie is negatief geformuleerd. Wat hier bedoeld wordt is dat er nog wel budget moet zijn. De minister stelt periodoek vast hoeveel budget hij per doelgroep beschikbaar stelt. Als dat geld op is, kan hij geen sbusdie meer verstrekken"
+      "sources": []
     },
     {
       "fact": "[studiejaar waarop subsidie betrekking heeft is voorbij]",
+      "explanation": "Impliciete beleidsregel bij vragen om beleidsstukken.",
       "function": "[]",
-      "sources": [],
-      "explanation": "Impliciete beleidsregel bij vragen om beleidsstukken."
+      "sources": []
     },
     {
       "fact": "[subsidieverplichting voor subsidie voor studieverlof]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 24, lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=24&lid=2",
-      "sourcetext": "Indien voldaan is aan de subsidieverplichting kan de subsidie voor studieverlof worden besteed aan andere activiteiten waarvoor bekostiging wordt verstrekt.",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[leraar is in dienst bij het bevoegd gezag]",
+      "explanation": "",
       "function": "[]",
-      "sources": [],
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag heeft studieverlof verleend aan de leraar]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 23 lid 1 Sbl",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=23&lid=1",
-      "sourcetext": "{Het bevoegd gezag verleent studieverlof aan de leraar.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[aan deze leraar is subsidie voor studiekosten verleend tenzij voor een opleiding geen collegegeld verschuldigd is]",
+      "explanation": "Fact toegevoegd, vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 20, onder b Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=20",
-      "sourcetext": "De subsidie voor studieverlof wordt slechts verstrekt aan het bevoegd gezag voor zover: b. aan deze leraar subsidie voor studiekosten is verleend tenzij voor een opleiding geen collegegeld verschuldigd is.",
-      "explanation": "Fact toegevoegd, vanwege warning"
+      "sources": []
     },
     {
       "fact": "[minister verstrekt subsidie lerarenbeurs aan bevoegd gezag]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 23 lid 1 Sbl",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=23&lid=1",
-      "sourcetext": "{Het bevoegd gezag verleent studieverlof aan de leraar.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[uit de administratie van het bevoegd gezag blijkt dat het studieverlof daadwerkelijk is verleend]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 23 lid 2 Sbl",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=3&artikel=23&lid=2",
-      "sourcetext": "{Uit de administratie van het bevoegd gezag blijkt dat het studieverlof daadwerkelijk is verleend.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[subsidie lerarenbeurs]",
+      "explanation": "",
       "function": "[]",
-      "sources": [],
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[subsidieverlening aan een leraar]",
+      "explanation": "Als fact toegevoegd omdat dit bij act bestuursorgaan weigert subsidievrelening aan belanghebbende als object benoend is",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact toegevoegd omdat dit bij act bestuursorgaan weigert subsidievrelening aan belanghebbende als object benoend is"
+      "sources": []
     },
     {
       "fact": "[orgaan]",
+      "explanation": "Added, because it was missing in excel. Dit is een tekstgedeelte uit de definitie van bestuursorgaan (artikel 1:1 Awb)",
       "function": "[]",
-      "sources": [],
-      "explanation": "Added, because it was missing in excel. Dit is een tekstgedeelte uit de definitie van bestuursorgaan (artikel 1:1 Awb)"
+      "sources": []
     },
     {
       "fact": "[persoon]",
+      "explanation": "Added, because it was missing in excel",
       "function": "[]",
-      "sources": [],
-      "explanation": "Added, because it was missing in excel"
+      "sources": []
     },
     {
       "fact": "[binnen twee maanden na het verstrekken van de subsidie]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 13, lid 2 onder a Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
-      "sourcetext": "De minister kan de subsidie voor studieverlof terugvorderen indien: de leraar binnen twee maanden na het verstrekken van de subsidie de aanvraag voor studieverlof of de aanvraag voor studiekosten intrekt;",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[niet, niet tijdig of niet geheel aan de subsidieverplichtingen zal worden voldaan]",
+      "explanation": "Fact toegevoegd, vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art 5.7, lid 1. onder b van de Kaderregeling subsidies OCW, SZW en VWS",
-      "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",
-      "sourcetext": "De subsidieontvanger meldt onverwijld schriftelijk aan de minister indien: aannemelijk is geworden dat niet, niet tijdig of niet geheel aan de subsidieverplichtingen zal worden voldaan",
-      "explanation": "Fact toegevoegd, vanwege warning"
+      "sources": []
     },
     {
       "fact": "[aan de subsidie verbonden verplichtingen zal worden voldaan]",
-      "function": "[]"
+      "explanation": "",
+      "function": "[]",
+      "sources": []
     },
     {
       "fact": "[een gegronde reden bestaat om aan te nemen dat de activiteiten niet of niet geheel zullen plaatsvinden]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 4:35, lid 1, onder a Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=1",
-      "sourcetext": "De subsidieverlening kan in ieder geval worden geweigerd indien een gegronde reden bestaat om aan te nemen dat: a. de activiteiten niet of niet geheel zullen plaatsvinden",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[een gegronde reden bestaat om aan te nemen dat de aanvrager niet zal voldoen aan de aan de subsidie verbonden verplichtingen]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 4:35, lid 1, onder b Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=1",
-      "sourcetext": "De subsidieverlening kan in ieder geval worden geweigerd indien een gegronde reden bestaat om aan te nemen dat: b. de aanvrager niet zal voldoen aan de aan de subsidie verbonden verplichtingen",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[een gegronde reden bestaat om aan te nemen dat de aanvrager niet op een behoorlijke wijze rekening en verantwoording zal afleggen omtrent de verrichte activiteiten en de daaraan verbonden uitgaven en inkomsten, voor zover deze voor de vaststelling van de subsidie van belang zijn]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 4:35, lid 1, onder c Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=1",
-      "sourcetext": "De subsidieverlening kan in ieder geval worden geweigerd indien een gegronde reden bestaat om aan te nemen dat de aanvrager niet op een behoorlijke wijze rekening en verantwoording zal afleggen omtrent de verrichtte activiteiten en de daaraan verbonden uitgaven en inkomsten, voor zover deze voor de vaststelling van de subsidie van belang zijn.",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[aanvrager heeft in het kader van de aanvraag onjuiste of onvolledige gegevens verstrekt]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art 4:35, lid 2, onder a Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=2",
-      "sourcetext": "De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager in het kader van de aanvraag onjuiste of onvolledige gegevens heeft verstrekt en de verstrekking van deze gegevens tot een onjuiste beschikking op de aanvraag zou hebben geleid",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[de verstrekking van deze gegevens tot een onjuiste beschikking op de aanvraag zou hebben geleid]",
+      "explanation": "Fact toegevoegd vanwege een warning",
       "function": "[]",
-      "version": "",
-      "art": "art 4:35, id 2, onder b Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=2",
-      "sourcetext": "De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager in het kader van de aanvraag onjuiste of onvolledige gegevens heeft verstrekt en de verstrekking van deze gegevens tot een onjuiste beschikking op de aanvraag zou hebben geleid",
-      "explanation": "Fact toegevoegd vanwege een warning"
+      "sources": []
     },
     {
       "fact": "[aanvrager is failliet verklaard]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 4:35 lid 2, onder b Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=2",
-      "sourcetext": "De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager failliet is verklaard ",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[aan aanvrager is surséance van betaling verleend]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art.4:35, lid 2, onder b Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=2",
-      "sourcetext": "De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager: b aan hem surséance van betaling is verleend",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[ten aanzien de aanvrager is de schuldsaneringsregeling natuurlijke personen van toepassing verklaard of een verzoek daartoe bij de rechtbank is ingediend]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 4:35, lid 2, onder b Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=2De subsidieverlening kan voorts in ieder geval worden geweigerd indien de aanvrager:b  ten aanzien van hem de schuldsaneringsregeling natuurlijke personen van toepassing is verklaard, dan wel een verzoek daartoe bij de rechtbank is ingediend.",
-      "sourcetext": " ten aanzien van hem de schuldsaneringsregeling natuurlijke personen van toepassing is verklaard, dan wel een verzoek daartoe bij de rechtbank is ingediend.",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[naar het oordeel van het bestuursorgaan is verstrekking van de subsidie niet verenigbaar met het bepaalde in de artikelen 107 en 108 van het Verdrag betreffende de werking van de Europese Unie.]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 4:35 lid 3 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.3&artikel=4:35&lid=3",
-      "sourcetext": "De subsidieverlening wordt voorts geweigerd indien de verstrekking van subsidie naar het oordeel van het bestuursorgaan niet verenigbaar is met het bepaalde in de artikelen 107 en 108 van het Verdrag betreffende de werking van de Europese Unie.",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag]",
+      "explanation": "Deze definitie is bewust ontkoppeld van de onderliggende definities. De hier gebruikte facts zijn als [] gedefinieerd en worden door een ssid ingevuld",
       "function": {
         "expression": "OR",
         "operands": [
@@ -1939,14 +1802,11 @@
           "[instellingsbestuur bedoeld in artikel 1.1, onderdeel j, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek]"
         ]
       },
-      "version": "",
-      "art": "art. 1, vijfde gedachtenstreepje Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=1",
-      "sourcetext": "{bevoegd gezag als bedoeld inartikel 1 van de Wet op het primair onderwijs,artikel 1 van de Wet op de expertisecentra,artikel 1 van de Wet op het voortgezet onderwijs,artikel 1.1.1., onderdeel w, van de Wet educatie en beroepsonderwijs,artikel 1 van de Wet primair onderwijs BES,artikel 1 van de Wet voortgezet onderwijs BES,artikel 1.1.1, van de Wet educatie en beroepsonderwijs BES, of instellingsbestuur bedoeld inartikel 1.1, onderdeel j, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek}",
-      "explanation": "Deze definitie is bewust ontkoppeld van de onderliggende definities. De hier gebruikte facts zijn als [] gedefinieerd en worden door een ssid ingevuld"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag van door Wet primair onderwijs bekostigde scholen]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -1974,56 +1834,53 @@
           "[een samenwerkingsschool: de stichting, bedoeld in artikel 17d]"
         ]
       },
-      "version": "",
-      "art": "Art. 1 Wet op het primair onderwijs",
-      "juriconnect": "jci1.3:c:BWBR0003420&hoofdstuk=I&titeldeel=I&artikel=1",
-      "sourcetext": "{bevoegd gezag van volgens deze wet bekostigde scholen:voor wat betreft\r\na. een openbare school:\r\n1°. burgemeester en wethouders, voor zover de raad niet anders bepaalt, en, indien de raad dit besluit, met inachtneming van door hem te stellen regelen;\r\n2°. het krachtens de desbetreffende gemeenschappelijke regeling bevoegde orgaan;\r\n3°. de openbare rechtspersoon, bedoeld inartikel 47; dan wel\r\n4°. de stichting, bedoeld inartikel 17ofartikel 48;\r\nb. een bijzondere school: de rechtspersoon bedoeld inartikel 55;\r\nc. een samenwerkingsschool: de stichting, bedoeld inartikel 17d;}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[een openbare school]",
+      "explanation": "als fact opgenomen omdat het in fact bevoegd gezag Wet Primair onderwijs als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact opgenomen omdat het in fact bevoegd gezag Wet Primair onderwijs als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[burgemeester en wethouders, voor zover de raad niet anders bepaalt, en, indien de raad dit besluit, met inachtneming van door hem te stellen regelen]",
+      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[het krachtens de desbetreffende gemeenschappelijke regeling bevoegde orgaan]",
+      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[de openbare rechtspersoon, bedoeld in artikel 47]",
+      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[de stichting, bedoeld in artikel 17 of artikel 48]",
+      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[een bijzondere school: de rechtspersoon bedoeld in artikel 55]",
+      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[een samenwerkingsschool: de stichting, bedoeld in artikel 17d]",
+      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "fact toegevoegd, omdat in het in fact bevoegd gezag Wet primair onderwijs als operand is benoemd"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag van door Wet expertisecentra bekostigde scholen]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2051,38 +1908,35 @@
           "[een samenwerkingsschool: de stichting, bedoeld in artikel 28j]"
         ]
       },
-      "version": "",
-      "art": "Art. 1 Wet expertisecentra",
-      "juriconnect": "jci1.3:c:BWBR0003549&titeldeel=I&artikel=1",
-      "sourcetext": "{bevoegd gezag van volgens deze wet bekostigde scholenvoor wat betreft:\r\na. een openbare school:\r\n1°. het college van burgemeester en wethouders, voor zover de raad niet anders bepaalt, en, indien de raad dit besluit, met inachtneming van door hem te stellen regelen;\r\n2°. het krachtens de desbetreffende gemeenschappelijke regeling bevoegde orgaan;\r\n 3°. de openbare rechtspersoon, bedoeld inartikel 50; dan wel\r\n4°. de stichting, bedoeld inartikel 28ofartikel 51;\r\n b. een bijzondere school: de rechtspersoon bedoeld inartikel 57;\r\nc. een samenwerkingsschool: de stichting, bedoeld inartikel 28j;}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[de openbare rechtspersoon, bedoeld in artikel 50]",
+      "explanation": "als fact benoemd, omdat dit als operand in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, omdat dit als operand in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd"
+      "sources": []
     },
     {
       "fact": "[de stichting, bedoeld in artikel 28 of artikel 51]",
+      "explanation": "als fact benoemd omdat dit als operand  in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd omdat dit als operand  in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd"
+      "sources": []
     },
     {
       "fact": "[een bijzondere school: de rechtspersoon bedoeld in artikel 57]",
+      "explanation": "als fact benoemd omdat dit als operand  in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd omdat dit als operand  in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd"
+      "sources": []
     },
     {
       "fact": "[een samenwerkingsschool: de stichting, bedoeld in artikel 28j]",
+      "explanation": "als fact benoemd omdat dit als operand  in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd omdat dit als operand  in fact bevoegd gezag van door Wet expertisecentra bekostigde scholen is benoemd"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag Wet op het voorgezet onderwijs]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2110,38 +1964,35 @@
           "[een samenwerkingsschool: de stichting, bedoeld in artikel 53d]"
         ]
       },
-      "version": "",
-      "art": "art. 1 Wet op het voortgezet onderwijs",
-      "juriconnect": "jci1.3:c:BWBR0002399&titeldeel=I&artikel=1",
-      "sourcetext": "{het bevoegd gezag : voor wat betreft:\r\na. een openbare school:\r\n1°. het college van burgemeester en wethouders, voor zover de raad niet anders bepaalt, en, indien de raad dit besluit, met inachtneming van door hem te stellen regelen;\r\n2°. het krachtens de desbetreffende gemeenschappelijke regeling bevoegde orgaan;\r\n3°. de openbare rechtspersoon, bedoeld inartikel 42a; dan wel\r\n 4°. de stichting, bedoeld inartikel 42bofartikel 53c;\r\nb. een bijzondere school: de rechtspersoon, bedoeld inartikel 49, eerste lid;\r\nc. een samenwerkingsschool: de stichting, bedoeld inartikel 53d;",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[de openbare rechtspersoon, bedoeld in artikel 42a]",
+      "explanation": "benoemd omdat het beoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "benoemd omdat het beoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs"
+      "sources": []
     },
     {
       "fact": "[de stichting, bedoeld in artikel 42b of artikel 53c]",
+      "explanation": "benoemd omdat het benoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "benoemd omdat het benoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs"
+      "sources": []
     },
     {
       "fact": "[een bijzondere school: de rechtspersoon, bedoeld in artikel 49, eerste lid]",
+      "explanation": "benoemd omdat het benoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "benoemd omdat het benoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs"
+      "sources": []
     },
     {
       "fact": "[een samenwerkingsschool: de stichting, bedoeld in artikel 53d]",
+      "explanation": "benoemd omdat het benoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "benoemd omdat het benoemd wordt in fact bevoegd gezag Wet voortgezet onderwijs"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag Wet educatie en beroepsonderwijs]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2163,44 +2014,41 @@
           "[wat een exameninstelling als bedoeld in artikel 1.6.1 betreft: het bestuur van de rechtspersoon waarvan de instelling uitgaat]"
         ]
       },
-      "version": "",
-      "art": "art. 1 Wet educatie en beroepsonderwijs",
-      "juriconnect": "jci1.3:c:BWBR0007625&hoofdstuk=I&titeldeel=1&artikel=1.1.1",
-      "sourcetext": "{bevoegd gezag:\r\n1. wat een openbare instelling betreft: het college van burgemeester en wethouders, voor zover de raad niet anders bepaalt, en, indien de raad dit wenselijk oordeelt, met inachtneming van door hem te stellen regelen, dan wel het krachtens de desbetreffende gemeenschappelijke regeling bevoegde orgaan;\r\n2. wat een bijzondere instelling betreft: het college van bestuur, of indienartikel 9.1.8is toegepast, het bestuur van de rechtspersoon waarvan de instelling uitgaat;\r\n3. wat een instelling als bedoeld in deartikelen 1.4.1dan wel1.4a.1betreft: het bestuur van de rechtspersoon waarvan de instelling uitgaat, dan wel de natuurlijke persoon die de instelling in stand houdt;\r\n4. wat een exameninstelling als bedoeld inartikel 1.6.1betreft: het bestuur van de rechtspersoon waarvan de instelling uitgaat}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[het college van burgemeester en wethouders, voor zover de raad niet anders bepaalt, en, indien de raad dit wenselijk oordeelt, met inachtneming van door hem te stellen regelen]",
+      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs"
+      "sources": []
     },
     {
       "fact": "[dan wel het krachtens de desbetreffende gemeenschappelijke regeling bevoegde orgaan]",
+      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs"
+      "sources": []
     },
     {
       "fact": "[wat een bijzondere instelling betreft: het college van bestuur, of indien artikel 9.1.8 is toegepast, het bestuur van de rechtspersoon waarvan de instelling uitgaat]",
+      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs"
+      "sources": []
     },
     {
       "fact": "[wat een instelling als bedoeld in de artikelen 1.4.1 dan wel 1.4a.1 betreft: het bestuur van de rechtspersoon waarvan de instelling uitgaat, dan wel de natuurlijke persoon die de instelling in stand houdt]",
+      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs"
+      "sources": []
     },
     {
       "fact": "[wat een exameninstelling als bedoeld in artikel 1.6.1 betreft: het bestuur van de rechtspersoon waarvan de instelling uitgaat]",
+      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs",
       "function": "[]",
-      "sources": [],
-      "explanation": "Als fact benoemd, want operand in fact bevoegd gezeg wet educatie en beroepsonderwijs"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag Wet primair onderwijs BES]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2216,38 +2064,35 @@
           "[een bijzondere school: de rechtspersoon, bedoeld in artikel 60]"
         ]
       },
-      "version": "",
-      "art": "Art. 1 Wet op het primair onderwijs BES",
-      "juriconnect": "jci1.3:c:BWBR0030280&hoofdstuk=I&titeldeel=I&artikel=1",
-      "sourcetext": "{bevoegd gezag: voor wat betreft\r\na. een openbare school:\r\n1°. het bestuurscollege van het betreffende openbaar lichaam, voor zover de eilandsraad niet anders bepaalt, en, indien de eilandsraad dit besluit, met inachtneming van door hem te stellen regelen;\r\n2°. de openbare rechtspersoon, bedoeld inartikel 53; dan wel\r\n3°. de stichting, bedoeld inartikel 54;\r\nb. een bijzondere school: de rechtspersoon, bedoeld inartikel 60}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[het bestuurscollege van het betreffende openbaar lichaam, voor zover de eilandsraad niet anders bepaalt, en, indien de eilandsraad dit besluit, met inachtneming van door hem te stellen regelen]",
+      "explanation": "als fact benoemd, want in fact bevoegd gezag  Wet primair onderwijs BES opgenomen als operand",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, want in fact bevoegd gezag  Wet primair onderwijs BES opgenomen als operand"
+      "sources": []
     },
     {
       "fact": "[de openbare rechtspersoon, bedoeld in artikel 53]",
+      "explanation": "als fact benoemd, want in fact bevoegd gezag  Wet primair onderwijs BES opgenomen als operand",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, want in fact bevoegd gezag  Wet primair onderwijs BES opgenomen als operand"
+      "sources": []
     },
     {
       "fact": "[de stichting, bedoeld in artikel 54]",
+      "explanation": "als fact benoemd, want in fact bevoegd Wet primair onderwijs BES opgenomen als operand",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, want in fact bevoegd Wet primair onderwijs BES opgenomen als operand"
+      "sources": []
     },
     {
       "fact": "[een bijzondere school: de rechtspersoon, bedoeld in artikel 60]",
+      "explanation": "als fact benoemd, want in fact bevoegd Wet primair onderwijs BES opgenomen als operand",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact benoemd, want in fact bevoegd Wet primair onderwijs BES opgenomen als operand"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag Wet op het voorgezet onderwijs BES]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2263,32 +2108,29 @@
           "[een bijzondere school: de rechtspersoon, bedoeld in artikel 105, eerste lid]"
         ]
       },
-      "version": "",
-      "art": "Art 1 Wet op het voortgezet onderwijs BES",
-      "juriconnect": "jci1.3:c:BWBR0030284&titeldeel=I&artikel=1",
-      "sourcetext": "{bevoegd gezag: voor wat betreft:\r\na. een openbare school:\r\n1°. het bestuurscollege van het betreffende openbaar lichaam, voor zover de raad niet anders bepaalt, en, indien de raad dit besluit, met inachtneming van door hem te stellen regelen;\r\n2°. de openbare rechtspersoon, bedoeld inartikel 97; dan wel\r\nb. een bijzondere school: de rechtspersoon, bedoeld inartikel 105, eerste lid}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[de openbare rechtspersoon, bedoeld in artikel 97]",
+      "explanation": "opgenenomen vanwege warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "opgenenomen vanwege warning"
+      "sources": []
     },
     {
       "fact": "[de stichting, bedoeld in artikel 98 of artikel 109]",
+      "explanation": "opgenomen vanwege warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "opgenomen vanwege warning"
+      "sources": []
     },
     {
       "fact": "[een bijzondere school: de rechtspersoon, bedoeld in artikel 105, eerste lid]",
+      "explanation": "opgenomen vanwege warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "opgenomen vanwege warning"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag Wet educatie en beroepsonderwijs BES]",
+      "explanation": "",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2309,32 +2151,29 @@
           "[wat een exameninstelling als bedoeld in artikel 1.6.1 betreft: het bestuur van de rechtspersoon waarvan de instelling uitgaat]"
         ]
       },
-      "version": "",
-      "art": "Art. 1 Wet educatie en beroepsonderwijs BES",
-      "juriconnect": "/jci1.3:c:BWBR0028395&hoofdstuk=1&titeldeel=1&artikel=1.1.1",
-      "sourcetext": "{bevoegd gezag:\r\n1. wat een openbare instelling betreft: het bestuurscollege, voor zover de eilandsraad niet anders bepaalt, en, indien de eilandsraad dit wenselijk oordeelt, met inachtneming van door hem te stellen regelen, dan wel het krachtens de desbetreffende gemeenschappelijke regeling bevoegde orgaan;\r\n2. wat een bijzondere instelling betreft: de natuurlijke persoon of het bestuur;\r\n3. wat een exameninstelling als bedoeld inartikel 1.6.1betreft: het bestuur van de rechtspersoon waarvan de instelling uitgaat}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[wat een openbare instelling betreft]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[het bestuurscollege, voor zover de eilandsraad niet anders bepaalt, en, indien de eilandsraad dit wenselijk oordeelt, met inachtneming van door hem te stellen regelen]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[wat een bijzondere instelling betreft: de natuurlijke persoon of het bestuur]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag, instellingbestuur Wet op het hoger onderwijs en wetenschappelijk onderzoek]",
+      "explanation": "Dit kan mogelijk verder uitgewerkt worden. Heb me niet helemaal aan de wettekst gehouden.",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2342,26 +2181,23 @@
           "[het orgaan dat als zodanig in de statuten is aangewezen]"
         ]
       },
-      "version": "",
-      "art": "Art. 1.1 Wet op het hoger onderwijs en wetenschappelijk onderzoek",
-      "juriconnect": "jci1.3:c:BWBR0005682&hoofdstuk=1&titeldeel=1&artikel=1.1",
-      "sourcetext": "{instellingsbestuur:\r\n – van een bekostigde instelling: het college van bestuur, tenzij anders bepaald;\r\n  – van een rechtspersoon met volledige rechtsbevoegdheid die geaccrediteerde opleidingen verzorgt: het orgaan dat als zodanig in de statuten is aangewezen}",
-      "explanation": "Dit kan mogelijk verder uitgewerkt worden. Heb me niet helemaal aan de wettekst gehouden."
+      "sources": []
     },
     {
       "fact": "[het orgaan dat als zodanig in de statuten is aangewezen]",
+      "explanation": "als fact opgenomen vanwege fact bevoegd gezag hoger onderwijs en wetenschappelijk onderzoek",
       "function": "[]",
-      "sources": [],
-      "explanation": "als fact opgenomen vanwege fact bevoegd gezag hoger onderwijs en wetenschappelijk onderzoek"
+      "sources": []
     },
     {
       "fact": "[het college van bestuur, tenzij anders bepaald]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[leraar]",
+      "explanation": "artikel XI van de Wet op de beroepen in het onderwijs. Dit is overgangsrecht en modelleer ik hier niet. Artikel zegt zoveel als dat bestaande bevoegdheden blijven. Verder heb ik ook de leraren lichamelijke opvoeding nog niet meegenomen. Deze definitie is bewust ontkoppeld van de onderliggende definities. De hier gebruikte facts zijn als [] gedefinieerd en worden door een ssid ingevuld",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2377,29 +2213,32 @@
           "[die lesgeeft in het hoger onderwijs]"
         ]
       },
-      "version": "",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=1",
           "validFrom": "25-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=1",
           "citation": "Art. 1, tiende gedachtenstreepje Slb",
-          "text": "{leraar:degene die voldoet aan bevoegdheidseisen gesteld in artikel 3 van de Wet op het primair onderwijs,artikel 3 van de Wet op de expertisecentra,artikel XI van de Wet op de beroepen in het onderwijsofartikel 3 van de Wet primair onderwijs BES, dan wel kan worden benoemd of tewerk kan worden gesteld zonder benoeming als bedoeld inartikel 33 van de Wet op het voortgezet onderwijs,artikel 4.2.1. van de Wet educatie en beroepsonderwijs,artikel 80 van de Wet voortgezet onderwijs BESofartikel 4.2.1 van de Wet educatie beroepsonderwijs BES, of die lesgeeft in het hoger onderwijs}"
+          "text": "{leraar:degene die voldoet aan bevoegdheidseisen gesteld in artikel 3 van de Wet op het primair onderwijs,artikel 3 van de Wet op de expertisecentra,artikel XI van de Wet op de beroepen in het onderwijsofartikel 3 van de Wet primair onderwijs BES, dan wel kan worden benoemd of tewerk kan worden gesteld zonder benoeming als bedoeld inartikel 33 van de Wet op het voortgezet onderwijs,artikel 4.2.1. van de Wet educatie en beroepsonderwijs,artikel 80 van de Wet voortgezet onderwijs BESofartikel 4.2.1 van de Wet educatie beroepsonderwijs BES, of die lesgeeft in het hoger onderwijs}",
+          "explanation": ""
         }
-      ],
-      "explanation": "artikel XI van de Wet op de beroepen in het onderwijs. Dit is overgangsrecht en modelleer ik hier niet. Artikel zegt zoveel als dat bestaande bevoegdheden blijven. Verder heb ik ook de leraren lichamelijke opvoeding nog niet meegenomen. Deze definitie is bewust ontkoppeld van de onderliggende definities. De hier gebruikte facts zijn als [] gedefinieerd en worden door een ssid ingevuld"
+      ]
     },
     {
       "fact": "[leraar met aanvraag]",
+      "explanation": "",
       "function": {
-        "expression": "CREATE",
-        "operands": [
-          "[leraar]",
+        "expression": "PROJECTION",
+        "context": [
           "[aanvraag]"
-        ]
-      }
+        ],
+        "fact": "[leraar]"
+      },
+      "sources": []
     },
     {
       "fact": "[leraar primair onderwijs]",
+      "explanation": "Ik heb er voor gekozen om alleen de verschillende subleden van het artikel te scheiden met 'of'. Als er binnen een artikelsublid nog een onderverdeling is gemaakt, heb ik die niet gemodelleerd, omdat die ten tijde van modelleren (190806) niet relevant is. Voor de definitie van leraar is alleen relevant welk soort leraren je hebt. De rest van artikel 3 heb ik niet gemodelleerd, omdat ik de hoofdregel wil modelleren en niet de uitzonderingen op dit moment",
       "function": {
         "expression": "AND",
         "operands": [
@@ -2416,50 +2255,47 @@
           "[niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten]"
         ]
       },
-      "version": "",
-      "art": "Art. 3, lid 1 Wet op het primaire onderwijs",
-      "juriconnect": "jci1.3:c:BWBR0003420&hoofdstuk=I&titeldeel=I&artikel=3&lid=1",
-      "sourcetext": "{Schoolonderwijs mag, onverminderd het derde lid, slechts worden gegeven door degene die:\r\na. in het bezit is van een verklaring omtrent het gedrag, afgegeven volgens de Wet justitiële en strafvorderlijke gegevens,\r\nb. in het bezit is van:\r\n1°. een getuigschrift, afgegeven krachtens de Wet op het hoger onderwijs en wetenschappelijk onderzoek, waaruit blijkt dat ten aanzien van dat onderwijs of ten aanzien van een of meer bij algemene maatregel van bestuur aan te wijzen daartoe behorende onderwijsactiviteiten als bedoeld inartikel 9is voldaan aan de bekwaamheidseisen die zijn vastgesteld krachtensartikel 32a, eerste lid, van deze wet, of krachtensartikel 36, eerste lid, van de Wet op het voortgezet onderwijs, of\r\n2°. een erkenning van beroepskwalificaties als bedoeld inartikel 5 van de Algemene wet erkenning EU-beroepskwalificaties, verleend ten aanzien van het onderwijs dat betrokkene zal geven, of\r\n3°. een geschiktheidsverklaring als bedoeld inartikel 176b, en\r\nc. niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten.}",
-      "explanation": "Ik heb er voor gekozen om alleen de verschillende subleden van het artikel te scheiden met 'of'. Als er binnen een artikelsublid nog een onderverdeling is gemaakt, heb ik die niet gemodelleerd, omdat die ten tijde van modelleren (190806) niet relevant is. Voor de definitie van leraar is alleen relevant welk soort leraren je hebt. De rest van artikel 3 heb ik niet gemodelleerd, omdat ik de hoofdregel wil modelleren en niet de uitzonderingen op dit moment"
+      "sources": []
     },
     {
       "fact": "[in het bezit is van een verklaring omtrent het gedrag, afgegeven volgens de Wet justitiële en strafvorderlijke gegevens]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[in het bezit is van:]",
+      "explanation": "oplossing warning. Wel de vraag of dit soort facts zinvol zijn",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning. Wel de vraag of dit soort facts zinvol zijn"
+      "sources": []
     },
     {
       "fact": "[een getuigschrift, afgegeven krachtens de Wet op het hoger onderwijs en wetenschappelijk onderzoek]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een geschiktheidsverklaring als bedoeld in artikel 176b]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een erkenning van beroepskwalificaties als bedoeld in artikel 5 van de Algemene wet erkenning EU-beroepskwalificaties, verleend ten aanzien van het onderwijs dat betrokkene zal geven]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[leraar speciaal en voortgezet onderwijs]",
+      "explanation": "Ik heb er voor gekozen om alleen de verschillende subleden van het artikel te scheiden met 'of'. Als er binnen een artikelsublid nog een onderverdeling is gemaakt, heb ik die niet gemodelleerd, omdat die ten tijde van modelleren (190806) niet relevant is. Voor de definitie van leraar is alleen relevant welk soort leraren je hebt. \r\nDe rest van artikel 3 heb ik niet gemodelleerd, omdat ik de hoofdregel wil modelleren en niet de uitzonderingen op dit moment",
       "function": {
         "expression": "AND",
         "operands": [
@@ -2475,26 +2311,23 @@
           "[niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten]"
         ]
       },
-      "version": "",
-      "art": "Art. 3, lid 1 Wet op de expertisecentra",
-      "juriconnect": "jci1.3:c:BWBR0003549&titeldeel=I&artikel=3&lid=1",
-      "sourcetext": "{Speciaal onderwijs en voortgezet speciaal onderwijs mag, onverminderd het derde en vierde lid, slechts worden gegeven door degene die:\r\na. in het bezit is van een verklaring omtrent het gedrag, afgegeven volgens deWet justitiële en strafvorderlijke gegevens,\r\nb. in het bezit is van:\r\n1°. een getuigschrift, afgegeven krachtens deWet op het hoger onderwijs en wetenschappelijk onderzoek, waaruit blijkt dat ten aanzien van dat onderwijs of ten aanzien van een of meer bij algemene maatregel van bestuur aan te wijzen onderdelen daarvan of vakken ingevolge deartikelen 13, eerste, tweede, vijfde en zesde lid,14a, tweede lid,14cen14f, is voldaan aan de bekwaamheidseisen die zijn vastgesteld krachtensartikel 32a, eerste lid, of krachtensartikel 36, eerste lid, van de Wet op het voortgezet onderwijs, of\r\n2°. een erkenning van beroepskwalificaties als bedoeld inartikel 5 van de Algemene wet erkenning EU-beroepskwalificaties, verleend ten aanzien van het onderwijs dat betrokkene zal geven, of\r\n3°. een geschiktheidsverklaring als bedoeld inartikel 162e, en\r\nc. niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten.",
-      "explanation": "Ik heb er voor gekozen om alleen de verschillende subleden van het artikel te scheiden met 'of'. Als er binnen een artikelsublid nog een onderverdeling is gemaakt, heb ik die niet gemodelleerd, omdat die ten tijde van modelleren (190806) niet relevant is. Voor de definitie van leraar is alleen relevant welk soort leraren je hebt. \r\nDe rest van artikel 3 heb ik niet gemodelleerd, omdat ik de hoofdregel wil modelleren en niet de uitzonderingen op dit moment"
+      "sources": []
     },
     {
       "fact": "[een getuigschrift, afgegeven krachtens de Wet op het hoger onderwijs en wetenschappelijk onderzoek, waaruit blijkt dat is voldaan aan de bekwaamheidseisen die zijn vastgesteld krachtens artikel 86, eerste lid]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een erkenning van beroepskwalificaties]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[leraar primair onderwijs BES]",
+      "explanation": "Ik heb er voor gekozen om alleen de verschillende subleden van het artikel te scheiden met 'of'. Als er binnen een artikelsublid nog een onderverdeling is gemaakt, heb ik die niet gemodelleerd, omdat die ten tijde van modelleren (190806) niet relevant is. Voor de definitie van leraar is alleen relevant welk soort leraren je hebt. \r\nDe rest van artikel 3 heb ik niet gemodelleerd, omdat ik de hoofdregel wil modelleren en niet de uitzonderingen op dit moment",
       "function": {
         "expression": "AND",
         "operands": [
@@ -2510,41 +2343,35 @@
           "[niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten]"
         ]
       },
-      "version": "",
-      "art": "Art. 3, lid 1 Wet op het primaire onderwijs BES",
-      "juriconnect": "jci1.3:c:BWBR0030280&hoofdstuk=I&titeldeel=I&artikel=3&lid=1",
-      "sourcetext": "{Schoolonderwijs mag, onverminderd het derde lid, slechts worden gegeven door degene die:\r\na. in het bezit is van een verklaring omtrent het gedrag, afgegeven volgens deWet op de justitiële documentatie en op de verklaringen omtrent het gedrag BES, die op het tijdstip van overlegging aan het bevoegd gezag niet ouder is dan zes maanden,\r\nb. in het bezit is van:\r\n1°. een getuigschrift, afgegeven krachtens de Wet op het hoger onderwijs en wetenschappelijk onderzoek, waaruit blijkt dat ten aanzien van dat onderwijs of ten aanzien van een of meer bij algemene maatregel van bestuur aan te wijzen daartoe behorende onderwijsactiviteiten als bedoeld in deartikelen 11of12is voldaan aan de bekwaamheidseisen die zijn vastgesteld krachtensartikel 35, eerste lid, van deze wet, of krachtensartikel 86, eerste lid, van de Wet voortgezet onderwijs BES,\r\n2°. een erkenning van beroepskwalificaties als bedoeld inartikel 5 van de Algemene wet erkenning EU-beroepskwalificaties, verleend ten aanzien van het onderwijs dat betrokkene zal geven, of\r\n3°. een geschiktheidsverklaring als bedoeld inartikel 137, en\r\nc. niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten.",
-      "explanation": "Ik heb er voor gekozen om alleen de verschillende subleden van het artikel te scheiden met 'of'. Als er binnen een artikelsublid nog een onderverdeling is gemaakt, heb ik die niet gemodelleerd, omdat die ten tijde van modelleren (190806) niet relevant is. Voor de definitie van leraar is alleen relevant welk soort leraren je hebt. \r\nDe rest van artikel 3 heb ik niet gemodelleerd, omdat ik de hoofdregel wil modelleren en niet de uitzonderingen op dit moment"
+      "sources": []
     },
     {
       "fact": "[in het bezit is van een verklaring omtrent het gedrag, afgegeven volgens de Wet op de justitiële documentatie en op de verklaringen omtrent het gedrag BES, die op het tijdstip van overlegging aan het bevoegd gezag niet ouder is dan zes maanden]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een getuigschrift, afgegeven krachtens de Wet op het hoger onderwijs en wetenschappelijk onderzoek, waaruit blijkt dat ten aanzien van dat onderwijs of ten aanzien van een of meer bij algemene maatregel van bestuur aan te wijzen daartoe behorende onderwijsactiviteiten als bedoeld in de artikelen 11 of 12 is voldaan aan de bekwaamheidseisen die zijn vastgesteld krachtens artikel 35, eerste lid, van deze wet, of krachtens artikel 86, eerste lid, van de Wet voortgezet onderwijs BES]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een geschiktheidsverklaring als bedoeld in artikel 137]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[Leraar voortgezet onderwijs, zonder benoeming]",
+      "explanation": "Ik weet nog niet hoe ik dit ga modelleren",
       "function": "[]",
-      "version": "",
-      "art": "Art. 33, lid 1 Wet op het voortgezet onderwijs",
-      "juriconnect": "jci1.3:c:BWBR0002399&titeldeel=II&afdeling=I&hoofdstuk=I&paragraaf=3&artikel=33&lid=1",
-      "sourcetext": "{Leraren worden door het bevoegd gezag benoemd dan wel tewerkgesteld zonder benoeming. Om tot leraar te kunnen worden benoemd of tewerkgesteld zonder benoeming dient de betrokkene:\r\na. in het bezit te zijn van een verklaring omtrent het gedrag, afgegeven volgens deWet justitiële en strafvorderlijke gegevens, die op het tijdstip van overlegging aan het bevoegd gezag niet ouder is dan 6 maanden,\r\nb. in het bezit te zijn van:\r\n1°. een getuigschrift, afgegeven krachtens deWet op het hoger onderwijs en wetenschappelijk onderzoek, waaruit blijkt dat is voldaan aan de bekwaamheidseisen die zijn vastgesteld krachtensartikel 36, eerste lid, of\r\n2°. een erkenning van beroepskwalificaties als bedoeld inartikel 5 van de Algemene wet erkenning EU-beroepskwalificaties, verleend ten aanzien van het onderwijs dat betrokkene zal geven, of\r\n3°. een geschiktheidsverklaring als bedoeld inartikel 118k, en\r\nc. niet krachtens rechterlijke uitspraak van het geven van onderwijs te zijn uitgesloten.\r\nDe eerste en tweede volzin zijn niet van toepassing op benoeming of tewerkstelling van leraren voor het verzorgen van een vak of ander programmaonderdeel dat door het bevoegd gezag is vastgesteld, uitgezonderd godsdienstonderwijs en levensbeschouwelijk vormingsonderwijs.}",
-      "explanation": "Ik weet nog niet hoe ik dit ga modelleren"
+      "sources": []
     },
     {
       "fact": "[Leraar educatie en beroepsonderwijs]",
+      "explanation": "",
       "function": {
         "expression": "AND",
         "operands": [
@@ -2565,56 +2392,53 @@
           "[niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten]"
         ]
       },
-      "version": "",
-      "art": "Art. 4.2.1. lid 2 Wet educatie en beroepsonderwijs",
-      "juriconnect": "jci1.3:c:BWBR0007625&hoofdstuk=4&titeldeel=2&artikel=4.2.1&lid=2",
-      "sourcetext": "{Tot docent aan een instelling kan slechts worden benoemd of tewerkgesteld zonder benoeming degene die:\r\na. in het bezit is van een verklaring omtrent het gedrag, afgegeven volgens deWet justitiële en strafvorderlijke gegevens, die op het tijdstip van overlegging aan het bevoegd gezag niet ouder is dan 6 maanden, en\r\nb. voldoet aan de bekwaamheidseisen, bedoeld inartikel 4.2.3, eerste lid, blijkend uit het bezit van:\r\n1°. een getuigschrift als bedoeld inartikel 7.11, eerste lid, van de Wet op het hoger onderwijs en wetenschappelijk onderzoekvan een met goed gevolg afgelegd afsluitend examen van een aan een hogeschool verbonden opleiding gericht op het beroep van leraar in het voortgezet onderwijs,\r\n2°. een getuigschrift als bedoeld in artikel 175 van de Wet op het hoger beroepsonderwijs van een met goed gevolg afgelegd staatsexamen, voor zover overeenkomend met een getuigschrift als bedoeld onder 1°,\r\n3°. een getuigschrift als bedoeld inartikel 7.11, eerste lid, van de Wet op het hoger onderwijs en wetenschappelijk onderzoekvan een met goed gevolg afgelegd afsluitend examen van een universitaire lerarenopleiding,\r\n4°. een getuigschrift of diploma van een opleiding die vóór 1 augustus 1991 was gericht op het beroep van leraar in het voortgezet onderwijs,\r\n5°. een ten aanzien van het door hem te geven onderwijs verleende erkenning van beroepskwalificaties als bedoeld inartikel 5 van de Algemene wet erkenning EU-beroepskwalificaties,\r\n6°. een gelijkwaardig buitenlands getuigschrift of diploma, behaald in een land dat niet behoort tot de Lid-Staten van de EU, dan wel een gelijkwaardig Nederlands-Antilliaans of Arubaans getuigschrift of diploma, of\r\n c. in het bezit is van een door het bevoegd gezag afgegeven geschiktheidsverklaring als bedoeld inartikel 4.2.4, en\r\nd. niet krachtens rechterlijke uitspraak is uitgesloten van het geven van onderwijs.",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[een getuigschrift als bedoeld in artikel 7.11, eerste lid, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek van een met goed gevolg afgelegd afsluitend examen van een aan een hogeschool verbonden opleiding gericht op het beroep van leraar in het voortgezet onderwijs]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een getuigschrift als bedoeld in artikel 175 van de Wet op het hoger beroepsonderwijs van een met goed gevolg afgelegd staatsexamen, voor zover overeenkomend met een getuigschrift als bedoeld onder 1°]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een getuigschrift als bedoeld in artikel 7.11, eerste lid, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek van een met goed gevolg afgelegd afsluitend examen van een universitaire lerarenopleiding]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een getuigschrift of diploma van een opleiding die vóór 1 augustus 1991 was gericht op het beroep van leraar in het voortgezet onderwijs]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een ten aanzien van het door hem te geven onderwijs verleende erkenning van beroepskwalificaties als bedoeld in artikel 5 van de Algemene wet erkenning EU-beroepskwalificaties]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een gelijkwaardig buitenlands getuigschrift of diploma, behaald in een land dat niet behoort tot de Lid-Staten van de EU, dan wel een gelijkwaardig Nederlands-Antilliaans of Arubaans getuigschrift of diploma]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[in het bezit is van een door het bevoegd gezag afgegeven geschiktheidsverklaring als bedoeld in artikel 4.2.4]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[Leraar voortgezet onderwijs BES]",
+      "explanation": "",
       "function": {
         "expression": "AND",
         "operands": [
@@ -2631,20 +2455,17 @@
           "[niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten]"
         ]
       },
-      "version": "",
-      "art": "Art. 80, lid 1, Wet voortgezet onderwijs BES",
-      "juriconnect": "jci1.3:c:BWBR0030284&titeldeel=II&afdeling=I&hoofdstuk=I&paragraaf=4&artikel=80&lid=1",
-      "sourcetext": "{Leraren worden door het bevoegd gezag benoemd dan wel tewerkgesteld zonder benoeming. Om tot leraar te kunnen worden benoemd of tewerkgesteld zonder benoeming dient de betrokkene:\r\na. in het bezit te zijn van een verklaring omtrent het gedrag, afgegeven volgens deWet op de justitiële documentatie en op de verklaringen omtrent het gedrag BES, die op het tijdstip van overlegging aan het bevoegd gezag niet ouder is dan 6 maanden,\r\nb. in het bezit te zijn van:\r\n 1°. een getuigschrift, afgegeven krachtens deWet op het hoger onderwijs en wetenschappelijk onderzoek, waaruit blijkt dat is voldaan aan de bekwaamheidseisen die zijn vastgesteld krachtensartikel 86, eerste lid, of\r\n  2°. een erkenning van beroepskwalificaties als bedoeld inartikel 5 van de Algemene wet erkenning EU-beroepskwalificaties, verleend ten aanzien van het onderwijs dat betrokkene zal geven, of\r\n3°. een geschiktheidsverklaring als bedoeld inartikel 197, en\r\n c. niet krachtens rechterlijke uitspraak van het geven van onderwijs te zijn uitgesloten.\r\nDe eerste en tweede volzin zijn niet van toepassing op benoeming of tewerkstelling van leraren voor het verzorgen van een vak of ander programmaonderdeel dat door het bevoegd gezag is vastgesteld, uitgezonderd godsdienstonderwijs en levensbeschouwelijk vormingsonderwijs.",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[een geschiktheidsverklaring als bedoeld in artikel 197]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[Leraar educatie en beroepsonderwijs BES]",
+      "explanation": "",
       "function": {
         "expression": "AND",
         "operands": [
@@ -2665,118 +2486,101 @@
           "[niet krachtens rechterlijke uitspraak van het geven van onderwijs is uitgesloten]"
         ]
       },
-      "version": "",
-      "art": "Art. 4.2.1. lid 2 Wet educatie en beroepsonderwijs BES",
-      "juriconnect": "jci1.3:c:BWBR0028395&hoofdstuk=4&titeldeel=2&artikel=4.2.1&lid=2",
-      "sourcetext": "{ot docent aan een instelling kan slechts worden benoemd of tewerkgesteld zonder benoeming degene die: \r\na. in het bezit is van een verklaring omtrent het gedrag, afgegeven volgens deWet op de justitiële documentatie en op de verklaringen omtrent het gedrag BES, die op het tijdstip van overlegging aan het bevoegd gezag niet ouder is dan 6 maanden, en\r\nb. voldoet aan de bekwaamheidseisen, bedoeld inartikel 4.2.3, eerste lid, blijkend uit het bezit van:\r\n1°. een getuigschrift als bedoeld inartikel 7.11, eerste lid, van de Wet op het hoger onderwijs en wetenschappelijk onderzoekvan een met goed gevolg afgelegd afsluitend examen van een aan een hogeschool verbonden opleiding gericht op het beroep van leraar in het voortgezet onderwijs,\r\n2°. een getuigschrift als bedoeld in artikel 175 van de Wet op het hoger beroepsonderwijs van een met goed gevolg afgelegd staatsexamen, voor zover overeenkomend met een getuigschrift als bedoeld onder 1°,\r\n3°. een getuigschrift als bedoeld inartikel 7.11, eerste lid, van de Wet op het hoger onderwijs en wetenschappelijk onderzoekvan een met goed gevolg afgelegd afsluitend examen van een universitaire lerarenopleiding,\r\n4°. een getuigschrift of diploma van een opleiding die vóór 1 augustus 1991 was gericht op het beroep van leraar in het voortgezet onderwijs,\r\n5°. een ten aanzien van het door hem te geven onderwijs verleende erkenning van beroepskwalificaties als bedoeld inartikel 5 van de Algemene wet erkenning EU-beroepskwalificaties,\r\n6°. een gelijkwaardig buitenlands getuigschrift of diploma, behaald in een land dat niet behoort tot de Lid-Staten van de EU, dan wel een gelijkwaardig diploma of getuigschrift behaald in Aruba, Curaçao, Sint Maarten, Bonaire, Sint Eustatius of Saba, of\r\nc. in het bezit is van een door het bevoegd gezag afgegeven geschiktheidsverklaring als bedoeld inartikel 4.2.5, en\r\n d. niet krachtens rechterlijke uitspraak is uitgesloten van het geven van onderwijs.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[in het bezit is van een door het bevoegd gezag afgegeven geschiktheidsverklaring als bedoeld in artikel 4.2.5]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[voldoet aan bekwaamheidseisen blijkend uit het bezit van]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[een gelijkwaardig buitenlands getuigschrift of diploma, behaald in een land dat niet behoort tot de Lid-Staten van de EU, dan wel een gelijkwaardig diploma of getuigschrift behaald in Aruba, Curaçao, Sint Maarten, Bonaire, Sint Eustatius of Saba]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[minister van Onderwijs, Cultuur en Wetenschap]",
+      "explanation": "Added, because it was missing in excel",
       "function": "[]",
-      "sources": [],
-      "explanation": "Added, because it was missing in excel"
+      "sources": []
     },
     {
       "fact": "[rechtspersoon die krachtens publiekrecht is ingesteld]",
+      "explanation": "Added, because it was missing in excel",
       "function": "[]",
-      "sources": [],
-      "explanation": "Added, because it was missing in excel"
+      "sources": []
     },
     {
       "fact": "[met enig openbaar gezag bekleed]",
+      "explanation": "Added, because it was missing in excel",
       "function": "[]",
-      "sources": [],
-      "explanation": "Added, because it was missing in excel"
+      "sources": []
     },
     {
       "fact": "[besluit tot verlenen subsidie voor kosten in verband met het verlenen van studieverlof aan de leraar]",
+      "explanation": "Added, because it was missing in excel. \r\nArtikel 20 Slb regelt het verlenen van subsidie voor studieverlof aan het bevoegd gezag. Artikel 24, eerste lid Slb regelt het verlenen van studieverlof aan de leraar door het bevoegd gezag.",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art.3 lid 1, onder b Slb",
-      "juriconnect": "",
-      "sourcetext": "",
-      "explanation": "Added, because it was missing in excel. \r\nArtikel 20 Slb regelt het verlenen van subsidie voor studieverlof aan het bevoegd gezag. Artikel 24, eerste lid Slb regelt het verlenen van studieverlof aan de leraar door het bevoegd gezag."
+      "sources": []
     },
     {
       "fact": "[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]",
+      "explanation": "Added, because it was missing in excel. \r\nIk zie wel dat de Minister van alles doet\/mag doen, beslissen binnen een termijn, hoogte subsidie bepalen enz. Weet bij dit specifieke fact niet zo snel ene wetsverwijzing. Heb nu volstaan met de algemene bevoegdheid uit de Awb.",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art. 4:23, lid 1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.2&afdeling=4.2.1&artikel=4:23&lid=1",
-      "sourcetext": "{Een bestuursorgaan verstrekt slechts subsidie op grond van een wettelijk voorschrift dat regelt voor welke activiteiten subsidie kan worden verstrekt}",
-      "explanation": "Added, because it was missing in excel. \r\nIk zie wel dat de Minister van alles doet/mag doen, beslissen binnen een termijn, hoogte subsidie bepalen enz. Weet bij dit specifieke fact niet zo snel ene wetsverwijzing. Heb nu volstaan met de algemene bevoegdheid uit de Awb."
+      "sources": []
     },
     {
       "fact": "[verzoek tot bewijs van het behalen van ten minste vijftien studiepunten]",
+      "explanation": "Added, because it was missing in excel",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "Art. 19, onder b Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
-      "sourcetext": "{een bewijsstuk waaruit blijkt dat hij ten minste vijftien studiepunten heeft behaald, dan wel een verklaring waarin staat dat leeruitkomsten zijn behaald bij een onderwijsinstelling die deelneemt aan het experiment leeruitkomsten ter waarde van in totaal ten minste vijftien studiepunten.}",
-      "explanation": "Added, because it was missing in excel"
+      "sources": []
     },
     {
       "fact": "[bewijsstuk waaruit blijkt dat hij ten minste vijftien studiepunten heeft gehaald]",
+      "explanation": "Fact teoegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 19, onder b Slb ",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
-      "sourcetext": "Op verzoek van de Minister toont de leraar aan dat hij voldoet aan de subsidiecriteria en de subsidieverplichtingen door het overleggen van: . een bewijsstuk waaruit blijkt dat hij ten minste vijftien studiepunten heeft behaald, dan wel een verklaring waarin staat dat leeruitkomsten zijn behaald bij een onderwijsinstelling die deelneemt aan het experiment leeruitkomsten ter waarde van in totaal ten minste vijftien studiepunten.",
-      "explanation": "Fact teoegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[verzoek tot bewijs van betaling van collegegeld]",
+      "explanation": "Added, because it was missing in excel",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "Art. 19, onder a Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
-      "sourcetext": "{een document waaruit blijkt dat hij collegegeld heeft betaald}",
-      "explanation": "Added, because it was missing in excel"
+      "sources": []
     },
     {
       "fact": "[bewijsstuk waaruit blijkt dat hij collegegeld heeft betaald]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "Art. 19, onder a Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=19",
-      "sourcetext": "Op verzoek van de Minister toont de leraar aan dat hij voldoet aan de subsidiecriteria en de subsidieverplichtingen door het overleggen van:a. een document waaruit blijkt dat hij collegegeld heeft betaalda. een document waaruit blijkt dat hij collegegeld heeft betaald.",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[subsidiebedrag is uitbetaald aan subsidieontvanger voordat de opleiding waar de subsidie betrekking op heeft aanvangt]",
+      "explanation": "",
       "function": "[]",
-      "sources": [],
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[terugvordering]",
+      "explanation": "Added, because it was missing in excel.",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2785,36 +2589,29 @@
           "[bevoegd gezag heeft geen studieverlof verleend]"
         ]
       },
-      "version": "",
-      "art": "Art. 13, lid 1 en 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
-      "sourcetext": "{De minister kan de subsidie voor studiekosten terugvorderen indien de leraar in de subsidieperiode minder dan vijftien studiepunten behaalt. De minister kan de subsidie voor studieverlof terugvorderen indien:\r\na. de leraar binnen twee maanden na het verstrekken van de subsidie de aanvraag voor studieverlof of de aanvraag voor studiekosten intrekt; of\r\nb. het bevoegd gezag geen studieverlof heeft verleend.}",
-      "explanation": "Added, because it was missing in excel."
+      "sources": []
     },
     {
       "fact": "[leraar heeft minder dan 15 studiepunten gehaald]",
+      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studiekosten",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "Art. 13, lid 1  Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
-      "sourcetext": "{De minister kan de subsidie voor studiekosten terugvorderen indien de leraar in de subsidieperiode minder dan vijftien studiepunten behaalt.}",
-      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studiekosten"
+      "sources": []
     },
     {
       "fact": "[leraar heeft binnen 2 maanden na verstrekking van de subsidie de aanvraag voor subsidie ingetrokken]",
+      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studiekosten",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "Art. 13, lid 2, aanhef en omnder a  Slb",
-      "juriconnect": "3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
-      "sourcetext": "{De minister kan de subsidie voor studieverlof terugvorderen indien: a. de leraar binnen twee maanden na het verstrekken van de subsidie de aanvraag voor studieverlof of de aanvraag voor studiekosten intrekt.}",
-      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studiekosten"
+      "sources": []
     },
     {
       "fact": "[terugvordering subsidie studieverlof]",
+      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studieverlof",
       "function": {
         "expression": "OR",
         "operands": [
@@ -2822,492 +2619,675 @@
           "[bevoegd gezag heeft geen studieverlof verleend]"
         ]
       },
-      "version": "",
-      "art": "Art. 13, lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
-      "sourcetext": "{De minister kan de subsidie voor studieverlof terugvorderen indien:\r\na. de leraar binnen twee maanden na het verstrekken van de subsidie de aanvraag voor studieverlof of de aanvraag voor studiekosten intrekt; of\r\nb. het bevoegd gezag geen studieverlof heeft verleend.}",
-      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studieverlof"
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag weigert studieverlof]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "Art. 13, lid 2 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=2",
-      "sourcetext": "{De minister kan de subsidie voor studieverlof terugvorderen indien:\r\na. de leraar binnen twee maanden na het verstrekken van de subsidie de aanvraag voor studieverlof of de aanvraag voor studiekosten intrekt; of\r\nb. het bevoegd gezag geen studieverlof heeft verleend.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[bevoegd gezag heeft geen studieverlof verleend]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[betalingsregeling voor het terugbetalen van de subsidie studiekosten]",
+      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studiekosten",
       "function": "[]",
-      "version": "",
-      "art": "Art. 13, lid 1 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=13&lid=1",
-      "sourcetext": "{De minister kan de subsidie voor  studiekosten terugvorderen indien de leraar in de subsidieperiode minder dan vijftien studiepunten behaalt.}",
-      "explanation": "Toegevoegd, want is preconditie voor het terugvorderen van subsidie studiekosten"
+      "sources": []
     },
     {
       "fact": "[terugvordering van collegegeld]",
+      "explanation": "",
       "function": "[studiekosten zijn lager dan de toegekende subsidie]",
-      "version": "",
-      "art": "Art. 16 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=2&artikel=16",
-      "sourcetext": "{Als het daadwerkelijk betaalde bedrag aan collegegeld lager is dan de verstrekte subsidie voor de kosten van collegegeld, kan de minister de subsidie voor de kosten van collegegeld, en naar rato de subsidie voor de kosten van studiemiddelen en reiskosten, terugvorderen, onverminderdartikel 13.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[studiekosten zijn lager dan de toegekende subsidie]",
+      "explanation": "oplossing warning",
       "function": "[]",
-      "sources": [],
-      "explanation": "oplossing warning"
+      "sources": []
     },
     {
       "fact": "[kosten van collegegeld, studiemiddelen en reiskosten]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "Art. 16 Slb",
-      "juriconnect": "ci1.3:c:BWBR0039319&hoofdstuk=2&artikel=16",
-      "sourcetext": "{Als het daadwerkelijk betaalde bedrag aan collegegeld lager is dan de verstrekte subsidie voor de kosten van collegegeld, kan de minister de subsidie voor de kosten van collegegeld, en naar rato de subsidie voor de kosten van studiemiddelen en reiskosten, terugvorderen, onverminderdartikel 13.}",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[subsidieontvanger]",
+      "explanation": "Toegevoegd, omdat deze bepaling uit de Kaderregeling ook regels bevat voor de Slb. Had deze er in eerste instantie uitgehaald",
       "function": {
-        "expression": "CREATE"
+        "expression": "CREATE",
+        "operands": []
       },
-      "version": "",
-      "art": "art. 5.7 lid 1, aanhef en onder b. Kaderregeling subsidies OCW, SZW en VWS",
-      "juriconnect": "jci1.3:c:BWBR0037603&hoofdstuk=5&artikel=5.7&lid=1",
-      "sourcetext": "{1 De subsidieontvanger meldt onverwijld schriftelijk aan de minister indien:\r\na. aannemelijk is geworden dat de activiteiten waarvoor de subsidie is verstrekt niet, niet tijdig of niet geheel zullen worden verricht,\r\nb. aannemelijk is geworden dat niet, niet tijdig of niet geheel aan de subsidieverplichtingen zal worden voldaan, of\r\nc. zich andere omstandigheden voordoen of zullen voordoen die van belang kunnen zijn voor een beslissing tot wijziging, intrekking of vaststelling van de subsidie.\r\n2 De melding wordt voorzien van een toelichting. Bij de melding worden de relevante stukken overgelegd.}",
-      "explanation": "Toegevoegd, omdat deze bepaling uit de Kaderregeling ook regels bevat voor de Slb. Had deze er in eerste instantie uitgehaald"
+      "sources": []
     },
     {
       "fact": "[een of meer bepalingen van de subsidieregeling lerarenbeurs]",
+      "explanation": "Fact toegevoegd vanwege warning",
       "function": "[]",
-      "version": "",
-      "art": "art. 26 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=4&artikel=26",
-      "sourcetext": "De minister kan een of meer bepalingen van deze regeling buiten toepassing laten of daarvan afwijken voor zover deze toepassing, gelet op het belang dat deze regeling beoogt te beschermen, zal leiden tot onbillijkheid van overwegende aard.",
-      "explanation": "Fact toegevoegd vanwege warning"
+      "sources": []
     },
     {
       "fact": "[minister OCW heeft een of meer bepalingen van de subsidieregeling lerarenbeurs buiten toepassing gelaten]",
+      "explanation": "",
       "function": "[]",
-      "version": "[]",
-      "art": "art. 26 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=4&artikel=26",
-      "sourcetext": "{De minister kan een of meer bepalingen van deze regeling buiten toepassing laten of daarvan afwijken voor zover deze toepassing, gelet op het belang dat deze regeling beoogt te beschermen, zal leiden tot onbillijkheid van overwegende aard.}",
-      "explanation": ""
+      "sources": []
     },
     {
-      "fact": "[minister OCW is afgeweken van een of meer bepalingen van de subsidieregeling lerarenbeurs ]",
+      "fact": "[minister OCW is afgeweken van een of meer bepalingen van de subsidieregeling lerarenbeurs]",
+      "explanation": "",
       "function": "[]",
-      "version": "",
-      "art": "art. 26 Slb",
-      "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=4&artikel=26",
-      "sourcetext": "{De minister kan een of meer bepalingen van deze regeling buiten toepassing laten of daarvan afwijken voor zover deze toepassing, gelet op het belang dat deze regeling beoogt te beschermen, zal leiden tot onbillijkheid van overwegende aard.}",
-      "explanation": ""
+      "sources": []
     },
     {
       "fact": "[artikel 1 van de Wet op het primair onderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 1 van de Wet op de expertisecentra]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 1 van de Wet op het voortgezet onderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 1.1.1., onderdeel w, van de Wet educatie en beroepsonderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 1 van de Wet primair onderwijs BES]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 1 van de Wet voortgezet onderwijs BES]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 1.1.1, van de Wet educatie en beroepsonderwijs BES]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[instellingsbestuur bedoeld in artikel 1.1, onderdeel j, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 3 van de Wet op het primair onderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 3 van de Wet op de expertisecentra]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel XI van de Wet op de beroepen in het onderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 3 van de Wet primair onderwijs BES]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[is benoemd of tewerkgesteld zonder benoeming als bedoeld in artikel 33 van de Wet op het voortgezet onderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 4.2.1. van de Wet educatie en beroepsonderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 80 van de Wet voortgezet onderwijs BES]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[artikel 4.2.1 van de Wet educatie beroepsonderwijs BES]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[die lesgeeft in het hoger onderwijs]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
     },
     {
       "fact": "[degene die voldoet aan bevoegdheidseisen gesteld in]",
+      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid",
       "function": "[]",
-      "sources": [],
-      "explanation": "Toegevoegd, omdat deze dan gekoppeld kan worden aan een ssid"
+      "sources": []
+    },
+    {
+      "fact": "[indienen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[bekendmaken]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[besluiten niet te behandelen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[vaststellen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[verstrekken]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[vragen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[terugvorderen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[treffen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[verzoeken]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[overleggen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[intrekken]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[melden]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[verlenen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[voldoen aan]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[buiten toepassing laten]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[afwijken van]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[weigeren]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[verdelen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
+    },
+    {
+      "fact": "[berekenen]",
+      "explanation": "GENERATED: This fact was generated during the 'Import From Json Action'",
+      "function": "[]",
+      "sources": []
     }
   ],
   "duties": [
     {
       "duty": "<schriftelijk indienen aanvraag>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[aanvrager]",
       "claimant": "[bestuursorgaan]",
       "create": "<<indienen aanvraag>>",
       "terminate": "<<bekendmaken besluit>>",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "reference": "art. 4:1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Tenzij bij wettelijk voorschrift anders is bepaald, wordt de aanvraag tot het geven van een beschikking schriftelijk ingediend bij het bestuursorgaan dat bevoegd is op de aanvraag te beslissen.}",
+      "sources": [],
       "explanation": "Bekendmaken beschikking"
     },
     {
       "duty": "<aanvraag indienen bij bevoegd bestuursorgaan>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[aanvrager]",
       "claimant": "[bestuursorgaan]",
       "create": "<<indienen aanvraag>>",
       "terminate": "<<bekendmaken besluit>>",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "reference": "art. 4:1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{Tenzij bij wettelijk voorschrift anders is bepaald, wordt de aanvraag tot het geven van een beschikking schriftelijk ingediend bij het bestuursorgaan dat bevoegd is op de aanvraag te beslissen.}",
+      "sources": [],
       "explanation": "Bekendmaken beschikking"
     },
     {
       "duty": "<aanvraag ondertekenen en naam aanvrager, adres, dagtekening en aanduiding doen bevatten>",
-      "duty-components": "<aanvraag ondertekenen>  \r\nEN  \r\n<aanvraag bevat de naam>  \r\nEN  \r\n<aanvraag bevat adres van de aanvrager>  \r\nEN  \r\n<aanvraag bevat dagtekening>  \r\nEN  \r\n<aanvraag bevat aanduiding van de beschikking die wordt gevraagd>",
+      "duty-components": [
+        "<aanvraag ondertekenen>",
+        "<aanvraag bevat de naam>",
+        "<aanvraag bevat adres van de aanvrager>",
+        "<aanvraag bevat dagtekening>",
+        "<aanvraag bevat aanduiding van de beschikking die wordt gevraagd>"
+      ],
       "duty-holder": "[aanvrager]",
       "claimant": "[bestuursorgaan]",
       "create": "<<indienen aanvraag>>",
       "terminate": "<<bekendmaken besluit>>",
-      "version": "2-[19940101]-[jjjjmmdd]",
-      "reference": "art. 4:2 lid 1 Awb",
-      "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:2&lid=1&z=2017-03-10&g=2017-03-10",
-      "sourcetext": "{De aanvraag wordt ondertekend en bevat ten minste:  \r\na. de naam en het adres van de aanvrager;  \r\nb. de dagtekening;  \r\nc. een aanduiding van de beschikking die wordt gevraagd.}",
+      "sources": [],
       "explanation": "Bekendmaken beschikking"
     },
     {
-      "duty": "<minister van OCW besluit binnen acht weken na het sluiten van de aanvraagtermijn>",
-      "duty-components": "",
-      "duty-holder": "[]",
-      "claimant": "[]",
-      "create": "",
-      "terminate": "",
-      "sources": [],
-      "explanation": ""
-    },
-    {
-      "duty": "<besluit om de aanvraag niet te behandelen wordt bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken>",
-      "duty-components": "",
-      "duty-holder": "[bestuursorgaan]",
-      "claimant": "[aanvrager]",
-      "create": "<<besluiten de aanvraag niet te behandelen>>",
-      "terminate": "<<bekendmaken besluit>>",
-      "sources": [
-        {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=4",
-          "validFrom": "01-07-2020",
-          "citation": "art. 4:5 lid 4 Awb",
-          "text": "{Een besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken.}"
-        }
-      ],
-      "version": "",
-      "explanation": ""
-    },
-    {
       "duty": "<verschaffen gegevens nodig om besluit te nemen>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[aanvrager]",
       "claimant": "[bestuursorgaan]",
       "create": "<<indienen aanvraag>>",
       "terminate": "<<bekendmaken besluit>>",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:2&lid=2&z=2017-03-10&g=2017-03-10",
           "validFrom": "10-03-2017",
-          "validTo": "31-03-2017", 
+          "validTo": "31-03-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:2&lid=2&z=2017-03-10&g=2017-03-10",
           "citation": "art. 4:2 lid 1 Awb",
-          "text": "De aanvrager verschaft voorts de gegevens en bescheiden die voor de beslissing op de aanvraag nodig zijn en waarover hij redelijkerwijs de beschikking kan krijgen."
+          "text": "De aanvrager verschaft voorts de gegevens en bescheiden die voor de beslissing op de aanvraag nodig zijn en waarover hij redelijkerwijs de beschikking kan krijgen.",
+          "explanation": ""
         }
       ],
-      "version": "2-[19940101]-[jjjjmmdd]",
       "explanation": "De [aanvrager] [verschaft] [voorts] de [gegevens en bescheiden] [die voor] de [beslissing op de aanvraag] [nodig zijn] [en] [waarover hij redelijkerwijs de beschikking kan krijgen]."
     },
     {
       "duty": "<vergaren nodige kennis>",
-      "duty-components": "<vergaren nodige kennis omtrent de relevante feiten>  \r\nEN  \r\n<vergaren nodige kennis omtrent  de af te wegen belangen >",
+      "duty-components": [
+        "<vergaren nodige kennis omtrent de relevante feiten>",
+        "<vergaren nodige kennis omtrent  de af te wegen belangen>"
+      ],
       "duty-holder": "[bestuursorgaan]",
       "claimant": "[belanghebbende]",
       "create": "<<indienen aanvraag>>",
       "terminate": "<<bekendmaken besluit>>",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.2&artikel=3:2&z=2017-03-10&g=2017-03-10",
           "validFrom": "10-03-2017",
           "validTo": "31-03-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.2&artikel=3:2&z=2017-03-10&g=2017-03-10",
           "citation": "art. 3:2 Awb",
-          "text": "{Bij de voorbereiding van een besluit vergaart het bestuursorgaan de nodige kennis omtrent de relevante feiten en de af te wegen belangen.}"
+          "text": "{Bij de voorbereiding van een besluit vergaart het bestuursorgaan de nodige kennis omtrent de relevante feiten en de af te wegen belangen.}",
+          "explanation": ""
         }
       ],
       "explanation": "Bekendmaken beschikking"
     },
     {
       "duty": "<besluit berust op deugdelijke motivering>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[bestuursorgaan]",
       "claimant": "[belanghebbende]",
       "create": "<<indienen aanvraag>>",
       "terminate": "<<bekendmaken besluit>>",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.7&artikel=3:46&z=2017-03-10&g=2017-03-10",
           "validFrom": "10-03-2017",
-          "validTo": "31-03-2017", 
+          "validTo": "31-03-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=3&afdeling=3.7&artikel=3:46&z=2017-03-10&g=2017-03-10",
           "citation": "art. 3:46 Awb",
-          "text": "{Een besluit dient te berusten op een deugdelijke motivering.}"
+          "text": "{Een besluit dient te berusten op een deugdelijke motivering.}",
+          "explanation": ""
         }
       ],
       "explanation": "Bekendmaken beschikking"
     },
     {
       "duty": "<beschikking geven binnen termijn>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[bestuursorgaan]",
       "claimant": "[belanghebbende]",
       "create": "<<indienen aanvraag>>",
       "terminate": "<<bekendmaken besluit>>",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.3&paragraaf=4.1.3.1&artikel=4:13&lid=1&z=2017-03-10&g=2017-03-10",
           "validFrom": "10-03-2017",
-          "validTo": "31-03-2017", 
+          "validTo": "31-03-2017",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.3&paragraaf=4.1.3.1&artikel=4:13&lid=1&z=2017-03-10&g=2017-03-10",
           "citation": "art. 4:13 lid 1 Awb",
-          "text": "{Een beschikking dient te worden gegeven binnen de bij wettelijk voorschrift bepaalde termijn of, bij het ontbreken van zulk een termijn, binnen een redelijke termijn na ontvangst van de aanvraag.}"
+          "text": "{Een beschikking dient te worden gegeven binnen de bij wettelijk voorschrift bepaalde termijn of, bij het ontbreken van zulk een termijn, binnen een redelijke termijn na ontvangst van de aanvraag.}",
+          "explanation": ""
         }
       ],
       "explanation": "Bekendmaken beschikking"
     },
     {
-      "duty": "<bekend maken besluit>",
-      "duty-components": "",
+      "duty": "<besluit om de aanvraag niet te behandelen wordt bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken>",
+      "duty-components": [],
+      "duty-holder": "[bestuursorgaan]",
+      "claimant": "[aanvrager]",
+      "create": "<<besluiten de aanvraag niet te behandelen>>",
+      "terminate": "<<bekendmaken besluit>>",
+      "sources": [
+        {
+          "validFrom": "01-07-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0005537&hoofdstuk=4&titeldeel=4.1&afdeling=4.1.1&artikel=4:5&lid=4",
+          "citation": "art. 4:5 lid 4 Awb",
+          "text": "{Een besluit om de aanvraag niet te behandelen wordt aan de aanvrager bekendgemaakt binnen vier weken nadat de aanvraag is aangevuld of nadat de daarvoor gestelde termijn ongebruikt is verstreken.}",
+          "explanation": ""
+        }
+      ],
+      "explanation": ""
+    },
+    {
+      "duty": "<minister van OCW besluit binnen acht weken na het sluiten van de aanvraagtermijn>",
+      "duty-components": [],
       "duty-holder": "[]",
       "claimant": "[]",
-      "create": "",
-      "terminate": "",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
-      "duty": "<subsidie voor studieverlof wordt aangevraagd door de leraar voor het bevoegd gezag>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
+      "duty": "<minister van OCW berekent de hoogte van de subsidie voor studiekosten>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
-      "duty": "<leraar voldoet aan subsidiecriteria>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
+      "duty": "<subsidiebedrag wordt uitbetaald aan subsidieontvanger voordat de opleiding waar de subsidie betrekking op heeft aanvangt>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
-      "duty": "<leraar voldoet aan subsidieverplichtingen>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
+      "duty": "<minister van OCW berekent de hoogte van de subsidie voor studieverlof>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": ""
+    },
+    {
+      "duty": "<bekend maken besluit>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
       "duty": "<subsidieverplichting voor subsidie voor studieverlof>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[]",
       "claimant": "[]",
-      "create": "",
-      "terminate": "",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": ""
+    },
+    {
+      "duty": "<aanvraag ondertekenen>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<aanvraag bevat de naam>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<aanvraag bevat adres van de aanvrager>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<aanvraag bevat dagtekening>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<aanvraag bevat aanduiding van de beschikking die wordt gevraagd>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<vergaren nodige kennis omtrent de relevante feiten>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<vergaren nodige kennis omtrent  de af te wegen belangen>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<subsidie voor studieverlof wordt aangevraagd door de leraar voor het bevoegd gezag>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": ""
+    },
+    {
+      "duty": "<leraar voldoet aan subsidiecriteria>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": ""
+    },
+    {
+      "duty": "<leraar voldoet aan subsidieverplichtingen>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
       "duty": "<minister van OCW betaalt subsidie studiekosten aan leraar>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[bestuursorgaan]",
       "claimant": "[leraar]",
       "create": "<verplichting behalen 15 studiepunten>",
       "terminate": "<betalingsverplichting>",
       "sources": [
         {
-          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=12",
           "validFrom": "24-06-2020",
+          "validTo": "",
+          "juriconnect": "jci1.3:c:BWBR0039319&hoofdstuk=1&artikel=12",
           "citation": "art. 12 Slb",
-          "text": "{Het subsidiebedrag wordt voordat de opleiding waar de subsidie betrekking op heeft aanvangt, aan de subsidieontvanger uitbetaald}"
+          "text": "{Het subsidiebedrag wordt voordat de opleiding waar de subsidie betrekking op heeft aanvangt, aan de subsidieontvanger uitbetaald}",
+          "explanation": ""
         }
       ],
       "explanation": "verplichting tot behalen 15 studiepunten bij create is strikt genomen een verplichting van de leraar. Ik vind em voor het uitwerken van de duty bestuursorgaan betaalt subsidie wel wat ver gaan."
     },
     {
+      "duty": "<verplichting behalen 15 studiepunten>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
+      "duty": "<betalingsverplichting>",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
+      "sources": [],
+      "explanation": "GENERATED: This duty was generated during the 'Import From Json Action'"
+    },
+    {
       "duty": "<minister trek Tijdelijke regeling lerarenbeurs in>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
       "duty": "<Regeling BWBR0039319 wordt aangehaald als Subsidieregeling lerarenbeurs>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
       "duty": "<de Subsidieregeling lerarenberus wordt met toelichting in de Staatscourant geplaatst>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
-      "sources": [],
-      "explanation": ""
-    },
-    {
-      "duty": "<minister van OCW berekent de hoogte van de subsidie voor studiekosten>",
-      "duty-components": "",
+      "duty-components": [],
       "duty-holder": "[]",
       "claimant": "[]",
-      "create": "",
-      "terminate": "",
-      "sources": [],
-      "explanation": ""
-    },
-    {
-      "duty": "<minister van OCW berekent de hoogte van de subsidie voor studieverlof>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
-      "sources": [],
-      "explanation": ""
-    },
-    {
-      "duty": "<subsidiebedrag wordt uitbetaald aan subsidieontvanger voordat de opleiding waar de subsidie betrekking op heeft aanvangt>",
-      "duty-components": "",
-      "duty-holder": "[]",
-      "claimant": "[]",
-      "create": "",
-      "terminate": "",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
       "duty": "<minister van OCW neemt verzoek om een besluit te nemen niet in behandeling>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     },
     {
       "duty": "<minister van OCW weigert de aanvraag>",
-      "duty-components": "",
-      "duty-holder": "",
-      "claimant": "",
-      "create": "",
-      "terminate": "",
+      "duty-components": [],
+      "duty-holder": "[]",
+      "claimant": "[]",
+      "create": "<<>>",
+      "terminate": "<<>>",
       "sources": [],
       "explanation": ""
     }

--- a/test/flint-example-lerarenbeurs.json
+++ b/test/flint-example-lerarenbeurs.json
@@ -960,8 +960,7 @@
     {
       "fact": "[besluit]",
       "function": {
-        "expression": "CREATE",
-        "operands": []
+        "expression": "CREATE"
       },
       "version": "2-[19980101]-[jjjjmmdd]",
       "art": "art. 1:3 lid 1 Awb",
@@ -1080,8 +1079,7 @@
     {
       "fact": "[aanvraag]",
       "function": {
-        "expression": "CREATE",
-        "operands": []
+        "expression": "CREATE"
       },
       "version": "2-[19980101]-[jjjjmmdd]",
       "art": "art. 1:3 lid 1 en 3 Awb",
@@ -1100,9 +1098,8 @@
     },
     {
       "fact": "[aanvraag subsidieverlening]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 4:35 Awb",
@@ -1112,9 +1109,8 @@
     },
     {
       "fact": "[aanvraag subsidie voor studiekosten]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 7 lid 1 Slb",
@@ -1124,9 +1120,8 @@
     },
     {
       "fact": "[aanvraag subsidie voor studieverlof]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 8 lid 1 Slb",
@@ -1136,9 +1131,8 @@
     },
     {
       "fact": "[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 7 lid 2 Slb",
@@ -1166,9 +1160,8 @@
     },
     {
       "fact": "[aanvraagformulieren studieverlof op de website van de Dienst Uitvoering Onderwijs]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 8 lid 2 Slb",
@@ -1196,9 +1189,8 @@
     },
     {
       "fact": "[subsidieontvanger studiekosten]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 3 lid 1 onder a Sbl",
@@ -1217,9 +1209,8 @@
     },
     {
       "fact": "[formulier voor het indienen van aanvragen en het verstrekken van gegevens is vastgesteld door bestuursorgaan]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "2-[19940101]-[jjjjmmdd]",
       "art": "art. 4:4 Awb",
@@ -2821,9 +2812,8 @@
     },
     {
       "fact": "[besluit tot verlenen subsidie voor kosten in verband met het verlenen van studieverlof aan de leraar]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art.3 lid 1, onder b Slb",
@@ -2833,9 +2823,8 @@
     },
     {
       "fact": "[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 4:23, lid 1 Awb",
@@ -2845,9 +2834,8 @@
     },
     {
       "fact": "[verzoek tot bewijs van het behalen van ten minste vijftien studiepunten]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "Art. 19, onder b Slb",
@@ -2866,9 +2854,8 @@
     },
     {
       "fact": "[verzoek tot bewijs van betaling van collegegeld]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "Art. 19, onder a Slb",
@@ -2912,9 +2899,8 @@
     },
     {
       "fact": "[leraar heeft minder dan 15 studiepunten gehaald]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "Art. 13, lid 1  Slb",
@@ -2924,9 +2910,8 @@
     },
     {
       "fact": "[leraar heeft binnen 2 maanden na verstrekking van de subsidie de aanvraag voor subsidie ingetrokken]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "Art. 13, lid 2, aanhef en omnder a  Slb",
@@ -3005,9 +2990,8 @@
     },
     {
       "fact": "[subsidieontvanger]",
-            "function": {
-        "expression": "CREATE",
-        "operands": []
+      "function": {
+        "expression": "CREATE"
       },
       "version": "",
       "art": "art. 5.7 lid 1, aanhef en onder b. Kaderregeling subsidies OCW, SZW en VWS",

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -609,288 +609,287 @@ describe('discipl-law-reg', () => {
 
     it('should be able to compare numbers', async () => {
       await testMathExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          '[three]',
-          '[five]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to compare literals', async () => {
-      await testMathExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 3
-          },
-          {
-            'expression': 'LITERAL',
-            'operand': 5
-          }
-        ]
-      },
-      {})
-    })
-
-    it('should be able to compare numbers with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          '[five]',
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to compare numbers equality with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          '[dozen]',
-          '[thirteen]'
-        ]
-      },
-      {
-        '[dozen]': 12,
-        '[thirteen]': 13
-      })
-    })
-
-    it('should be able to add numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'SUM',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[eight]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5,
-        '[eight]': 8
-      })
-    })
-
-    it('should be able to add in a list', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'SUM',
-            'operands': [
-              {
-                'expression': 'LIST',
-                'items': '[number]'
-              }
-            ]
-          },
-          '[eight]'
-        ]
-      },
-      {
-        '[number]': [3, 5, false],
-        '[eight]': 8
-      })
-    })
-
-    it('should be able to add numbers with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'SUM',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[nine]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5,
-        '[nine]': 9
-      })
-    })
-
-    it('should be able to determine the minimum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MIN',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to evaluate a literal boolean', async () => {
-      await testMathExpression({
-        'expression': 'LITERAL',
-        'operand': true
-      },
-      {
-      })
-    })
-
-    it('should be able to determine the minimum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MIN',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to multiply in a list', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'PRODUCT',
-            'operands': [
-              {
-                'expression': 'LIST',
-                'items': '[number]'
-              }
-            ]
-          },
-          '[fifteen]'
-        ]
-      },
-      {
-        '[number]': [3, 5, false],
-        '[fifteen]': 15
-      })
-    })
-
-    it('should be able to multiply numbers with arbitrary precision', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'PRODUCT',
-            'operands': [
-              {
-                'expression': 'LITERAL',
-                'operand': 1.15
-              }, '[400]', '[100]'
-            ]
-          },
-          '[46000]'
-        ]
-      },
-      {
-        '[400]': 400,
-        '[100]': 100,
-        '[46000]': 46000
-      })
-    })
-
-    it('should be able to multiply numbers with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'PRODUCT',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[fourteen]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5,
-        '[fourteen]': 14
-      })
-    })
-
-    it('should be able to determine the maximum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MAX',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[five]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to determine the minimum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MIN',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should throw an error with unknown expressions', async () => {
-      let errorMessage
-      try {
-        await testMathExpression({
-          'expression': 'BANANAS',
+          'expression': 'LESS_THAN',
           'operands': [
-            '[three]', '[five]'
+            '[three]',
+            '[five]'
           ]
         },
         {
           '[three]': 3,
           '[five]': 5
         })
+    })
+
+    it('should be able to compare literals', async () => {
+      await testMathExpression({
+          'expression': 'LESS_THAN',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 3
+            },
+            {
+              'expression': 'LITERAL',
+              'operand': 5
+            }
+          ]
+        },
+        {})
+    })
+
+    it('should be able to compare numbers with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'LESS_THAN',
+          'operands': [
+            '[five]',
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to compare numbers equality with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            '[dozen]',
+            '[thirteen]'
+          ]
+        },
+        {
+          '[dozen]': 12,
+          '[thirteen]': 13
+        })
+    })
+
+    it('should be able to add numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'SUM',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[eight]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5,
+          '[eight]': 8
+        })
+    })
+
+    it('should be able to add in a list', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'SUM',
+              'operands': [
+                {
+                  'expression': 'LIST',
+                  'items': '[number]'
+                }
+              ]
+            },
+            '[eight]'
+          ]
+        },
+        {
+          '[number]': [3, 5, false],
+          '[eight]': 8
+        })
+    })
+
+    it('should be able to add numbers with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'SUM',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[nine]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5,
+          '[nine]': 9
+        })
+    })
+
+    it('should be able to determine the minimum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MIN',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to evaluate a literal boolean', async () => {
+      await testMathExpression({
+          'expression': 'LITERAL',
+          'operand': true
+        },
+        {})
+    })
+
+    it('should be able to determine the minimum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MIN',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to multiply in a list', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'PRODUCT',
+              'operands': [
+                {
+                  'expression': 'LIST',
+                  'items': '[number]'
+                }
+              ]
+            },
+            '[fifteen]'
+          ]
+        },
+        {
+          '[number]': [3, 5, false],
+          '[fifteen]': 15
+        })
+    })
+
+    it('should be able to multiply numbers with arbitrary precision', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'PRODUCT',
+              'operands': [
+                {
+                  'expression': 'LITERAL',
+                  'operand': 1.15
+                }, '[400]', '[100]'
+              ]
+            },
+            '[46000]'
+          ]
+        },
+        {
+          '[400]': 400,
+          '[100]': 100,
+          '[46000]': 46000
+        })
+    })
+
+    it('should be able to multiply numbers with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'PRODUCT',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[fourteen]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5,
+          '[fourteen]': 14
+        })
+    })
+
+    it('should be able to determine the maximum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MAX',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[five]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to determine the minimum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MIN',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should throw an error with unknown expressions', async () => {
+      let errorMessage
+      try {
+        await testMathExpression({
+            'expression': 'BANANAS',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          {
+            '[three]': 3,
+            '[five]': 5
+          })
       } catch (e) {
         errorMessage = e.message
       }
@@ -1014,8 +1013,7 @@ describe('discipl-law-reg', () => {
           { 'fact': '[overheid]', 'function': '[]', 'reference': '' },
           { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE', 'operands': [] }, 'reference': '' }
         ],
-        'duties': [
-        ]
+        'duties': []
       }
 
       const lawmakerSsid = await core.newSsid('ephemeral')
@@ -1122,8 +1120,7 @@ describe('discipl-law-reg', () => {
             'version': '2-[19980101]-[jjjjmmdd]',
             'juriconnect': 'jci1.3:c:BWBR0005537&hoofdstuk=1&titeldeel=1.1&artikel=1:3&lid=3&z=2017-03-01&g=2017-03-01'
           }],
-        'facts': [
-        ],
+        'facts': [],
         'duties': []
       }, ['actor'], {})
 
@@ -1227,8 +1224,7 @@ describe('discipl-law-reg', () => {
           { 'fact': '[overheid]', 'function': '[]', 'reference': '' },
           { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE', 'operands': [] }, 'reference': '' }
         ],
-        'duties': [
-        ]
+        'duties': []
       }
 
       const lawmakerSsid = await core.newSsid('ephemeral')
@@ -1369,7 +1365,7 @@ describe('discipl-law-reg', () => {
       const action = await core.get(secondActionLink, bestuursorgaanSsid)
 
       const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-        .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
+      .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
 
       expect(action.data).to.deep.equal({
         'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
@@ -1621,8 +1617,7 @@ describe('discipl-law-reg', () => {
       const result = await lawReg.checkAction(modelLink, actsLink, ssid, { 'factResolver': factResolver })
 
       expect(result).to.deep.equal({
-        'invalidReasons': [
-        ],
+        'invalidReasons': [],
         'valid': true
       })
     })
@@ -1648,8 +1643,7 @@ describe('discipl-law-reg', () => {
       const result = await lawReg.checkAction(modelLink, actsLink, ssid, { 'factResolver': factResolver })
 
       expect(result).to.deep.equal({
-        'invalidReasons': [
-        ],
+        'invalidReasons': [],
         'valid': true
       })
     })
@@ -1770,121 +1764,119 @@ describe('discipl-law-reg', () => {
 
     it('should be able to explain an expression', async () => {
       await explainExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 'banana'
-          },
-          '[favourite meal]'
-        ]
-      },
-      {
-        '[favourite meal]': 'banana'
-      },
-      {
-        'fact': '[expression]',
-        'operandExplanations': [
-          {
-            'expression': 'EQUAL',
-            'operandExplanations': [
-              {
-                'expression': 'LITERAL',
-                'value': 'banana'
-              },
-              {
-                'fact': '[favourite meal]',
-                'operandExplanations': [
-                  {
-                    'value': 'banana'
-                  }
-                ],
-                'value': 'banana'
-              }
-            ],
-            'value': true
-          }
-        ],
-        'value': true
-      }
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 'banana'
+            },
+            '[favourite meal]'
+          ]
+        },
+        {
+          '[favourite meal]': 'banana'
+        },
+        {
+          'fact': '[expression]',
+          'operandExplanations': [
+            {
+              'expression': 'EQUAL',
+              'operandExplanations': [
+                {
+                  'expression': 'LITERAL',
+                  'value': 'banana'
+                },
+                {
+                  'fact': '[favourite meal]',
+                  'operandExplanations': [
+                    {
+                      'value': 'banana'
+                    }
+                  ],
+                  'value': 'banana'
+                }
+              ],
+              'value': true
+            }
+          ],
+          'value': true
+        }
       )
     })
 
     it('should be able to explain a less-than expression', async () => {
       await explainExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 5
-          },
-          {
-            'expression': 'LITERAL',
-            'operand': 6
-          }
-        ]
-      },
-      {
-      },
-      {
-        'fact': '[expression]',
-        'operandExplanations': [
-          {
-            'expression': 'LESS_THAN',
-            'operandExplanations': [
-              {
-                'expression': 'LITERAL',
-                'value': '5'
-              },
-              {
-                'expression': 'LITERAL',
-                'value': '6'
-              }
-            ],
-            'value': true
-          }
-        ],
-        'value': true
-      }
+          'expression': 'LESS_THAN',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 5
+            },
+            {
+              'expression': 'LITERAL',
+              'operand': 6
+            }
+          ]
+        },
+        {},
+        {
+          'fact': '[expression]',
+          'operandExplanations': [
+            {
+              'expression': 'LESS_THAN',
+              'operandExplanations': [
+                {
+                  'expression': 'LITERAL',
+                  'value': '5'
+                },
+                {
+                  'expression': 'LITERAL',
+                  'value': '6'
+                }
+              ],
+              'value': true
+            }
+          ],
+          'value': true
+        }
       )
     })
 
     it('should be able to explain a min expression', async () => {
       await explainExpression({
-        'expression': 'MIN',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 5
-          },
-          {
-            'expression': 'LITERAL',
-            'operand': 6
-          }
-        ]
-      },
-      {
-      },
-      {
-        'fact': '[expression]',
-        'operandExplanations': [
-          {
-            'expression': 'MIN',
-            'operandExplanations': [
-              {
-                'expression': 'LITERAL',
-                'value': '5'
-              },
-              {
-                'expression': 'LITERAL',
-                'value': '6'
-              }
-            ],
-            'value': '5'
-          }
-        ],
-        'value': '5'
-      }
+          'expression': 'MIN',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 5
+            },
+            {
+              'expression': 'LITERAL',
+              'operand': 6
+            }
+          ]
+        },
+        {},
+        {
+          'fact': '[expression]',
+          'operandExplanations': [
+            {
+              'expression': 'MIN',
+              'operandExplanations': [
+                {
+                  'expression': 'LITERAL',
+                  'value': '5'
+                },
+                {
+                  'expression': 'LITERAL',
+                  'value': '6'
+                }
+              ],
+              'value': '5'
+            }
+          ],
+          'value': '5'
+        }
       )
     })
   })
@@ -2076,7 +2068,7 @@ describe('discipl-law-reg', () => {
       expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
     })
 
-    it.only('should allow OR expressions', async () => {
+    it('should allow OR expressions', async () => {
       const model = {
         'acts': [
           {
@@ -2143,6 +2135,127 @@ describe('discipl-law-reg', () => {
   })
 
   describe('PROJECTION expression', async function () {
+    it('should call getPotentialActs multiple times without breaking PROJECTION expressions', async () => {
+      const model = {
+        'acts': [
+          {
+            'act': '<<subsidie aanvragen>>',
+            'actor': '[burger]',
+            'action': '[aanvragen]',
+            'object': '[verzoek]',
+            'recipient': '[ambtenaar]',
+            'preconditions': '[bedrag]',
+            'create': [
+              '[aanvraag]'
+            ],
+            'terminate': [],
+            'sources': [],
+            'explanation': ''
+          },
+          {
+            'act': '<<subsidie aanvraag toekennen>>',
+            'actor': '[ambtenaar]',
+            'action': '[toekennen]',
+            'object': '[aanvraag]',
+            'recipient': '[burger]',
+            'preconditions': {
+              'expression': 'LESS_THAN',
+              'operands': [
+                '[bedrag projection]',
+                {
+                  'expression': 'LITERAL',
+                  'operand': 500
+                }
+              ]
+            },
+            'create': [],
+            'terminate': [],
+            'sources': [],
+            'explanation': ''
+          }
+        ],
+        'facts': [
+          {
+            'fact': '[bedrag]',
+            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
+            'function': '[]',
+            'sources': []
+          },
+          {
+            'fact': '[aanvraag]',
+            'explanation': '',
+            'function': {
+              'expression': 'CREATE',
+              'operands': [
+                '[bedrag]'
+              ]
+            },
+            'sources': []
+          },
+          {
+            'fact': '[bedrag projection]',
+            'explanation': '',
+            'function': {
+              'expression': 'PROJECTION',
+              'context': [
+                '[aanvraag]'
+              ],
+              'fact': '[bedrag]'
+            },
+            'sources': []
+          },
+          {
+            'fact': '[burger]',
+            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
+            'function': '[]',
+            'sources': []
+          },
+          {
+            'fact': '[verzoek]',
+            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
+            'function': '[]',
+            'sources': []
+          },
+          {
+            'fact': '[ambtenaar]',
+            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
+            'function': '[]',
+            'sources': []
+          },
+          {
+            'fact': '[aanvragen]',
+            'explanation': '',
+            'function': '[]',
+            'sources': []
+          },
+          {
+            'fact': '[toekennen]',
+            'explanation': '',
+            'function': '[]',
+            'sources': []
+          }
+        ],
+        'duties': []
+      }
+      const core = lawReg.getAbundanceService().getCoreAPI()
+      const util = new Util(lawReg)
+      const { ssids, modelLink } = await util.setupModel(model, ['burger', 'ambtenaar'], { '[ambtenaar]': 'ambtenaar', '[burger]': 'burger' })
+
+      const needLink = await core.claim(ssids['burger'], {
+        'need': {
+          'act': '<<subsidie aanvragen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const potentialActs = (await lawReg.getPotentialActs(needLink, ssids['burger'], [], [])).map((actInfo) => actInfo.act)
+
+      expect(potentialActs).to.deep.equal(['<<subsidie aanvragen>>'])
+
+      const potentialActs2 = (await lawReg.getPotentialActs(needLink, ssids['ambtenaar'], [], [])).map((actInfo) => actInfo.act)
+      expect(potentialActs2).to.deep.equal([])
+    })
+
     it('should get the projected property', async () => {
       const model = {
         'acts': [

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2136,111 +2136,113 @@ describe('discipl-law-reg', () => {
   })
 
   describe('PROJECTION expression', async function () {
-    it('should call getPotentialActs multiple times without breaking PROJECTION expressions', async () => {
-      const model = {
-        'acts': [
-          {
-            'act': '<<subsidie aanvragen>>',
-            'actor': '[burger]',
-            'action': '[aanvragen]',
-            'object': '[verzoek]',
-            'recipient': '[ambtenaar]',
-            'preconditions': '[bedrag]',
-            'create': [
+    const subsidieModel = {
+      'acts': [
+        {
+          'act': '<<subsidie aanvragen>>',
+          'actor': '[burger]',
+          'action': '[aanvragen]',
+          'object': '[verzoek]',
+          'recipient': '[ambtenaar]',
+          'preconditions': '[bedrag]',
+          'create': [
+            '[aanvraag]'
+          ],
+          'terminate': [],
+          'sources': [],
+          'explanation': ''
+        },
+        {
+          'act': '<<subsidie aanvraag toekennen>>',
+          'actor': '[ambtenaar]',
+          'action': '[toekennen]',
+          'object': '[aanvraag]',
+          'recipient': '[burger]',
+          'preconditions': {
+            'expression': 'LESS_THAN',
+            'operands': [
+              '[bedrag projection]',
+              {
+                'expression': 'LITERAL',
+                'operand': 500
+              }
+            ]
+          },
+          'create': [],
+          'terminate': [
+            '[aanvraag]'
+          ],
+          'sources': [],
+          'explanation': ''
+        }
+      ],
+      'facts': [
+        {
+          'fact': '[bedrag]',
+          'explanation': "GENERATED: This fact was generated during the 'Import From Json Action'",
+          'function': '[]',
+          'sources': []
+        },
+        {
+          'fact': '[aanvraag]',
+          'explanation': '',
+          'function': {
+            'expression': 'CREATE',
+            'operands': [
+              '[bedrag]'
+            ]
+          },
+          'sources': []
+        },
+        {
+          'fact': '[bedrag projection]',
+          'explanation': '',
+          'function': {
+            'expression': 'PROJECTION',
+            'context': [
               '[aanvraag]'
             ],
-            'terminate': [],
-            'sources': [],
-            'explanation': ''
+            'fact': '[bedrag]'
           },
-          {
-            'act': '<<subsidie aanvraag toekennen>>',
-            'actor': '[ambtenaar]',
-            'action': '[toekennen]',
-            'object': '[aanvraag]',
-            'recipient': '[burger]',
-            'preconditions': {
-              'expression': 'LESS_THAN',
-              'operands': [
-                '[bedrag projection]',
-                {
-                  'expression': 'LITERAL',
-                  'operand': 500
-                }
-              ]
-            },
-            'create': [],
-            'terminate': [],
-            'sources': [],
-            'explanation': ''
-          }
-        ],
-        'facts': [
-          {
-            'fact': '[bedrag]',
-            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
-            'function': '[]',
-            'sources': []
-          },
-          {
-            'fact': '[aanvraag]',
-            'explanation': '',
-            'function': {
-              'expression': 'CREATE',
-              'operands': [
-                '[bedrag]'
-              ]
-            },
-            'sources': []
-          },
-          {
-            'fact': '[bedrag projection]',
-            'explanation': '',
-            'function': {
-              'expression': 'PROJECTION',
-              'context': [
-                '[aanvraag]'
-              ],
-              'fact': '[bedrag]'
-            },
-            'sources': []
-          },
-          {
-            'fact': '[burger]',
-            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
-            'function': '[]',
-            'sources': []
-          },
-          {
-            'fact': '[verzoek]',
-            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
-            'function': '[]',
-            'sources': []
-          },
-          {
-            'fact': '[ambtenaar]',
-            'explanation': 'GENERATED: This fact was generated during the \'Import From Json Action\'',
-            'function': '[]',
-            'sources': []
-          },
-          {
-            'fact': '[aanvragen]',
-            'explanation': '',
-            'function': '[]',
-            'sources': []
-          },
-          {
-            'fact': '[toekennen]',
-            'explanation': '',
-            'function': '[]',
-            'sources': []
-          }
-        ],
-        'duties': []
-      }
+          'sources': []
+        },
+        {
+          'fact': '[burger]',
+          'explanation': "GENERATED: This fact was generated during the 'Import From Json Action'",
+          'function': '[]',
+          'sources': []
+        },
+        {
+          'fact': '[verzoek]',
+          'explanation': "GENERATED: This fact was generated during the 'Import From Json Action'",
+          'function': '[]',
+          'sources': []
+        },
+        {
+          'fact': '[ambtenaar]',
+          'explanation': "GENERATED: This fact was generated during the 'Import From Json Action'",
+          'function': '[]',
+          'sources': []
+        },
+        {
+          'fact': '[aanvragen]',
+          'explanation': '',
+          'function': '[]',
+          'sources': []
+        },
+        {
+          'fact': '[toekennen]',
+          'explanation': '',
+          'function': '[]',
+          'sources': []
+        }
+      ],
+      'duties': []
+    }
+    it('should call getPotentialActs multiple times without breaking PROJECTION expressions', async () => {
       const core = lawReg.getAbundanceService().getCoreAPI()
       const util = new Util(lawReg)
-      const { ssids, modelLink } = await util.setupModel(model, ['burger', 'ambtenaar'], { '[ambtenaar]': 'ambtenaar', '[burger]': 'burger' })
+      const { ssids, modelLink } = await util.setupModel(subsidieModel, ['burger', 'ambtenaar'], { '[ambtenaar]': 'ambtenaar', '[burger]': 'burger' })
 
       const needLink = await core.claim(ssids['burger'], {
         'need': {
@@ -2440,7 +2442,7 @@ describe('discipl-law-reg', () => {
       expect(errorMessage).to.equal('')
     })
 
-    it('should not allow an act if the projection faild', async () => {
+    it('should not allow an act if the projection failed', async () => {
       const model = {
         'acts': [
           {
@@ -2500,6 +2502,49 @@ describe('discipl-law-reg', () => {
 
       expect(completeFacts).to.deep.include({ '[bedrag]': 500 })
       expect(errorMessage).to.equal('Action <<subsidie aanvraag toekennen>> is not allowed')
+    })
+
+    it('should be able to take an action after object is created from other action', async () => {
+      const core = lawReg.getAbundanceService().getCoreAPI()
+
+      const util = new Util(lawReg)
+      const { ssids, modelLink } = await util.setupModel(subsidieModel, ['burger', 'ambtenaar'], { '[ambtenaar]': 'ambtenaar', '[burger]': 'burger' })
+
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<subsidie aanvragen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const factResolver = (fact) => {
+        if (fact === '[bedrag]') return 50
+        return fact === '[verzoek]'
+      }
+
+      const actionLink = await lawReg.take(ssids['burger'], needLink, '<<subsidie aanvragen>>', factResolver)
+
+      const ambtenaarAvailableActs = (await lawReg.getAvailableActs(actionLink, ssids['ambtenaar'], [], [])).map((actInfo) => actInfo.act)
+
+      expect(ambtenaarAvailableActs).to.deep.equal(['<<subsidie aanvraag toekennen>>'])
+
+      const burgerPotentialActs = (await lawReg.getPotentialActs(actionLink, ssids['burger'], [], [])).map((actInfo) => actInfo.act)
+
+      expect(burgerPotentialActs).to.deep.equal(['<<subsidie aanvragen>>'])
+
+      const burgerAvailableActs = (await lawReg.getAvailableActs(actionLink, ssids['burger'], [], [])).map((actInfo) => actInfo.act)
+
+      expect(burgerAvailableActs).to.deep.equal([])
+
+      const actionLink2 = await lawReg.take(ssids['ambtenaar'], actionLink, '<<subsidie aanvraag toekennen>>', factResolver)
+
+      const ambtenaarAvailableActsAfterAanvraagToegekend = (await lawReg.getAvailableActs(actionLink2, ssids['ambtenaar'], [], [])).map((actInfo) => actInfo.act)
+
+      expect(ambtenaarAvailableActsAfterAanvraagToegekend).to.deep.equal([])
     })
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -2075,6 +2075,71 @@ describe('discipl-law-reg', () => {
       expect(acts).to.not.deep.include({ 'act': '<<bedrag vaststellen>>', 'actor': 'ouder' })
       expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
     })
+
+    it.only('should allow OR expressions', async () => {
+      const model = {
+        'acts': [
+          {
+            'act': '<<aanvragen kinderbijslag>>',
+            'actor': '[ouder]',
+            'recipient': '[ambtenaar]',
+            'object': '[verzoek]',
+            'preconditions': '[maximaal]',
+            'create': [
+              '[aanvraag]'
+            ]
+          },
+          {
+            'act': '<<aanvraag kinderbijslag toekennen>>',
+            'actor': '[ambtenaar]',
+            'object': '[aanvraag]',
+            'recipient': '[ouder]'
+          }
+        ],
+        'facts': [
+          {
+            'fact': '[aanvraag]',
+            'function': {
+              'expression': 'CREATE',
+              'operands': [
+                {
+                  'expression': 'OR',
+                  'operands': [
+                    '[bedrag]',
+                    '[maximaal]'
+                  ]
+                }
+              ]
+            }
+          }
+        ],
+        'duties': []
+      }
+
+      const completeFacts = { '[ouder]': true, '[ambtenaar]': true, '[verzoek]': true, '[maximaal]': true }
+      const util = new Util(lawReg)
+
+      const { ssids, modelLink } = await util.setupModel(model, ['ambtenaar', 'ouder'], completeFacts)
+      const acts = [
+        {
+          'act': '<<aanvragen kinderbijslag>>',
+          'actor': 'ouder'
+        },
+        {
+          'act': '<<aanvraag kinderbijslag toekennen>>',
+          'actor': 'ambtenaar'
+        }
+      ]
+
+      let errorMessage = ''
+      try {
+        await util.scenarioTest(ssids, modelLink, acts, completeFacts)
+      } catch (e) {
+        errorMessage = e.message
+      }
+
+      expect(errorMessage).to.equal('')
+    })
   })
 
   describe('PROJECTION expression', async function () {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -197,10 +197,10 @@ describe('discipl-law-reg', () => {
 
       expect(action.data).to.deep.equal({
         'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
-        'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['ingezetene'].did,
         'DISCIPL_FLINT_FACTS_SUPPLIED': {
           '[overheid]': true,
-          '[verwelkomst]': true
+          '[verwelkomst]': true,
+          '[ingezetene]': `IS:${ssids['ingezetene'].did}`
         },
         'DISCIPL_FLINT_GLOBAL_CASE': needLink,
         'DISCIPL_FLINT_PREVIOUS_CASE': needLink
@@ -309,8 +309,8 @@ describe('discipl-law-reg', () => {
 
       expect(action.data).to.deep.equal({
         'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
-        'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['ingezetene1'].did,
         'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[ingezetene]': `IS:${ssids['ingezetene1'].did}`,
           '[verwelkomst]': true
         },
         'DISCIPL_FLINT_GLOBAL_CASE': needLink,
@@ -376,10 +376,10 @@ describe('discipl-law-reg', () => {
       expect(action).to.deep.equal({
         'data': {
           'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
-          'DISCIPL_FLINT_ACT_TAKEN_BY': actorSsid.did,
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
             '[overheid]': true,
-            '[verwelkomst]': true
+            '[verwelkomst]': true,
+            '[ingezetene]': `IS:${actorSsid.did}`
           },
           'DISCIPL_FLINT_GLOBAL_CASE': needLink,
           'DISCIPL_FLINT_PREVIOUS_CASE': needLink
@@ -459,9 +459,8 @@ describe('discipl-law-reg', () => {
       expect(action).to.deep.equal({
         'data': {
           'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
-          'DISCIPL_FLINT_ACT_TAKEN_BY': actorSsid.did,
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
-            '[ouder]': true,
+            '[ouder]': `IS:${actorSsid.did}`,
             '[overheid]': true,
             '[verzoek]': true,
             'leeftijden': [
@@ -558,9 +557,8 @@ describe('discipl-law-reg', () => {
       expect(action).to.deep.equal({
         'data': {
           'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
-          'DISCIPL_FLINT_ACT_TAKEN_BY': actorSsid.did,
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
-            '[ouder]': true,
+            '[ouder]': `IS:${actorSsid.did}`,
             '[overheid]': true,
             '[verzoek]': true,
             'kinderen': [
@@ -724,287 +722,287 @@ describe('discipl-law-reg', () => {
 
     it('should be able to compare numbers', async () => {
       await testMathExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          '[three]',
-          '[five]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to compare literals', async () => {
-      await testMathExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 3
-          },
-          {
-            'expression': 'LITERAL',
-            'operand': 5
-          }
-        ]
-      },
-      {})
-    })
-
-    it('should be able to compare numbers with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          '[five]',
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to compare numbers equality with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          '[dozen]',
-          '[thirteen]'
-        ]
-      },
-      {
-        '[dozen]': 12,
-        '[thirteen]': 13
-      })
-    })
-
-    it('should be able to add numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'SUM',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[eight]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5,
-        '[eight]': 8
-      })
-    })
-
-    it('should be able to add in a list', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'SUM',
-            'operands': [
-              {
-                'expression': 'LIST',
-                'items': '[number]'
-              }
-            ]
-          },
-          '[eight]'
-        ]
-      },
-      {
-        '[number]': [3, 5, false],
-        '[eight]': 8
-      })
-    })
-
-    it('should be able to add numbers with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'SUM',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[nine]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5,
-        '[nine]': 9
-      })
-    })
-
-    it('should be able to determine the minimum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MIN',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to evaluate a literal boolean', async () => {
-      await testMathExpression({
-        'expression': 'LITERAL',
-        'operand': true
-      },
-      {})
-    })
-
-    it('should be able to determine the minimum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MIN',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to multiply in a list', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'PRODUCT',
-            'operands': [
-              {
-                'expression': 'LIST',
-                'items': '[number]'
-              }
-            ]
-          },
-          '[fifteen]'
-        ]
-      },
-      {
-        '[number]': [3, 5, false],
-        '[fifteen]': 15
-      })
-    })
-
-    it('should be able to multiply numbers with arbitrary precision', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'PRODUCT',
-            'operands': [
-              {
-                'expression': 'LITERAL',
-                'operand': 1.15
-              }, '[400]', '[100]'
-            ]
-          },
-          '[46000]'
-        ]
-      },
-      {
-        '[400]': 400,
-        '[100]': 100,
-        '[46000]': 46000
-      })
-    })
-
-    it('should be able to multiply numbers with a false result', async () => {
-      await testFalseMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'PRODUCT',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[fourteen]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5,
-        '[fourteen]': 14
-      })
-    })
-
-    it('should be able to determine the maximum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MAX',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[five]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should be able to determine the minimum of numbers', async () => {
-      await testMathExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'MIN',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          '[three]'
-        ]
-      },
-      {
-        '[three]': 3,
-        '[five]': 5
-      })
-    })
-
-    it('should throw an error with unknown expressions', async () => {
-      let errorMessage
-      try {
-        await testMathExpression({
-          'expression': 'BANANAS',
+          'expression': 'LESS_THAN',
           'operands': [
-            '[three]', '[five]'
+            '[three]',
+            '[five]'
           ]
         },
         {
           '[three]': 3,
           '[five]': 5
         })
+    })
+
+    it('should be able to compare literals', async () => {
+      await testMathExpression({
+          'expression': 'LESS_THAN',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 3
+            },
+            {
+              'expression': 'LITERAL',
+              'operand': 5
+            }
+          ]
+        },
+        {})
+    })
+
+    it('should be able to compare numbers with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'LESS_THAN',
+          'operands': [
+            '[five]',
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to compare numbers equality with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            '[dozen]',
+            '[thirteen]'
+          ]
+        },
+        {
+          '[dozen]': 12,
+          '[thirteen]': 13
+        })
+    })
+
+    it('should be able to add numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'SUM',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[eight]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5,
+          '[eight]': 8
+        })
+    })
+
+    it('should be able to add in a list', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'SUM',
+              'operands': [
+                {
+                  'expression': 'LIST',
+                  'items': '[number]'
+                }
+              ]
+            },
+            '[eight]'
+          ]
+        },
+        {
+          '[number]': [3, 5, false],
+          '[eight]': 8
+        })
+    })
+
+    it('should be able to add numbers with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'SUM',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[nine]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5,
+          '[nine]': 9
+        })
+    })
+
+    it('should be able to determine the minimum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MIN',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to evaluate a literal boolean', async () => {
+      await testMathExpression({
+          'expression': 'LITERAL',
+          'operand': true
+        },
+        {})
+    })
+
+    it('should be able to determine the minimum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MIN',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to multiply in a list', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'PRODUCT',
+              'operands': [
+                {
+                  'expression': 'LIST',
+                  'items': '[number]'
+                }
+              ]
+            },
+            '[fifteen]'
+          ]
+        },
+        {
+          '[number]': [3, 5, false],
+          '[fifteen]': 15
+        })
+    })
+
+    it('should be able to multiply numbers with arbitrary precision', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'PRODUCT',
+              'operands': [
+                {
+                  'expression': 'LITERAL',
+                  'operand': 1.15
+                }, '[400]', '[100]'
+              ]
+            },
+            '[46000]'
+          ]
+        },
+        {
+          '[400]': 400,
+          '[100]': 100,
+          '[46000]': 46000
+        })
+    })
+
+    it('should be able to multiply numbers with a false result', async () => {
+      await testFalseMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'PRODUCT',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[fourteen]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5,
+          '[fourteen]': 14
+        })
+    })
+
+    it('should be able to determine the maximum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MAX',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[five]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should be able to determine the minimum of numbers', async () => {
+      await testMathExpression({
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'MIN',
+              'operands': [
+                '[three]', '[five]'
+              ]
+            },
+            '[three]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
+    })
+
+    it('should throw an error with unknown expressions', async () => {
+      let errorMessage
+      try {
+        await testMathExpression({
+            'expression': 'BANANAS',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          {
+            '[three]': 3,
+            '[five]': 5
+          })
       } catch (e) {
         errorMessage = e.message
       }
@@ -1412,8 +1410,8 @@ describe('discipl-law-reg', () => {
       expect(action).to.deep.equal({
         'data': {
           'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
-          'DISCIPL_FLINT_ACT_TAKEN_BY': actorSsid.did,
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
+            '[belanghebbende]': `IS:${actorSsid.did}`,
             '[bij wettelijk voorschrift is anders bepaald]': false,
             '[verzoek een besluit te nemen]': true,
             '[wetgevende macht]': true
@@ -1481,12 +1479,12 @@ describe('discipl-law-reg', () => {
       const action = await core.get(secondActionLink, bestuursorgaanSsid)
 
       const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-        .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
+      .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
 
       expect(action.data).to.deep.equal({
         'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-        'DISCIPL_FLINT_ACT_TAKEN_BY': bestuursorgaanSsid.did,
         'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[bestuursorgaan]': `IS:${bestuursorgaanSsid.did}`,
           '[aanvraag]': actionLink,
           '[aanvraag is geheel of gedeeltelijk geweigerd op grond van artikel 2:15 Awb]': true
         },
@@ -1697,7 +1695,7 @@ describe('discipl-law-reg', () => {
       const eatDetails = await core.get(eatAction, ssids['baker'])
 
       expect(eatDetails.data['DISCIPL_FLINT_FACTS_SUPPLIED']).to.deep.equal({
-        '[baker]': true,
+        '[baker]': `IS:${ssids['baker'].did}`,
         '[bakery]': true,
         '[cookie]': firstBakeAction
       })
@@ -1707,7 +1705,7 @@ describe('discipl-law-reg', () => {
       const eatDetails2 = await core.get(eatAction2, ssids['baker'])
 
       expect(eatDetails2.data['DISCIPL_FLINT_FACTS_SUPPLIED']).to.deep.equal({
-        '[baker]': true,
+        '[baker]': `IS:${ssids['baker'].did}`,
         '[bakery]': true,
         '[cookie]': secondBakeAction
       })
@@ -1881,119 +1879,119 @@ describe('discipl-law-reg', () => {
 
     it('should be able to explain an expression', async () => {
       await explainExpression({
-        'expression': 'EQUAL',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 'banana'
-          },
-          '[favourite meal]'
-        ]
-      },
-      {
-        '[favourite meal]': 'banana'
-      },
-      {
-        'fact': '[expression]',
-        'operandExplanations': [
-          {
-            'expression': 'EQUAL',
-            'operandExplanations': [
-              {
-                'expression': 'LITERAL',
-                'value': 'banana'
-              },
-              {
-                'fact': '[favourite meal]',
-                'operandExplanations': [
-                  {
-                    'value': 'banana'
-                  }
-                ],
-                'value': 'banana'
-              }
-            ],
-            'value': true
-          }
-        ],
-        'value': true
-      }
+          'expression': 'EQUAL',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 'banana'
+            },
+            '[favourite meal]'
+          ]
+        },
+        {
+          '[favourite meal]': 'banana'
+        },
+        {
+          'fact': '[expression]',
+          'operandExplanations': [
+            {
+              'expression': 'EQUAL',
+              'operandExplanations': [
+                {
+                  'expression': 'LITERAL',
+                  'value': 'banana'
+                },
+                {
+                  'fact': '[favourite meal]',
+                  'operandExplanations': [
+                    {
+                      'value': 'banana'
+                    }
+                  ],
+                  'value': 'banana'
+                }
+              ],
+              'value': true
+            }
+          ],
+          'value': true
+        }
       )
     })
 
     it('should be able to explain a less-than expression', async () => {
       await explainExpression({
-        'expression': 'LESS_THAN',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 5
-          },
-          {
-            'expression': 'LITERAL',
-            'operand': 6
-          }
-        ]
-      },
-      {},
-      {
-        'fact': '[expression]',
-        'operandExplanations': [
-          {
-            'expression': 'LESS_THAN',
-            'operandExplanations': [
-              {
-                'expression': 'LITERAL',
-                'value': '5'
-              },
-              {
-                'expression': 'LITERAL',
-                'value': '6'
-              }
-            ],
-            'value': true
-          }
-        ],
-        'value': true
-      }
+          'expression': 'LESS_THAN',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 5
+            },
+            {
+              'expression': 'LITERAL',
+              'operand': 6
+            }
+          ]
+        },
+        {},
+        {
+          'fact': '[expression]',
+          'operandExplanations': [
+            {
+              'expression': 'LESS_THAN',
+              'operandExplanations': [
+                {
+                  'expression': 'LITERAL',
+                  'value': '5'
+                },
+                {
+                  'expression': 'LITERAL',
+                  'value': '6'
+                }
+              ],
+              'value': true
+            }
+          ],
+          'value': true
+        }
       )
     })
 
     it('should be able to explain a min expression', async () => {
       await explainExpression({
-        'expression': 'MIN',
-        'operands': [
-          {
-            'expression': 'LITERAL',
-            'operand': 5
-          },
-          {
-            'expression': 'LITERAL',
-            'operand': 6
-          }
-        ]
-      },
-      {},
-      {
-        'fact': '[expression]',
-        'operandExplanations': [
-          {
-            'expression': 'MIN',
-            'operandExplanations': [
-              {
-                'expression': 'LITERAL',
-                'value': '5'
-              },
-              {
-                'expression': 'LITERAL',
-                'value': '6'
-              }
-            ],
-            'value': '5'
-          }
-        ],
-        'value': '5'
-      }
+          'expression': 'MIN',
+          'operands': [
+            {
+              'expression': 'LITERAL',
+              'operand': 5
+            },
+            {
+              'expression': 'LITERAL',
+              'operand': 6
+            }
+          ]
+        },
+        {},
+        {
+          'fact': '[expression]',
+          'operandExplanations': [
+            {
+              'expression': 'MIN',
+              'operandExplanations': [
+                {
+                  'expression': 'LITERAL',
+                  'value': '5'
+                },
+                {
+                  'expression': 'LITERAL',
+                  'value': '6'
+                }
+              ],
+              'value': '5'
+            }
+          ],
+          'value': '5'
+        }
       )
     })
   })
@@ -2277,7 +2275,7 @@ describe('discipl-law-reg', () => {
           },
           {
             'act': '<<subsidie aanvraag intrekken>>',
-            'actor': '[burger]',
+            'actor': '[burger with aanvraag]',
             'action': '[intrekken]',
             'object': '[aanvraag]',
             'recipient': '[ambtenaar]',
@@ -2327,7 +2325,7 @@ describe('discipl-law-reg', () => {
               'expression': 'CREATE',
               'operands': [
                 '[bedrag]',
-                '[bsn]'
+                '[burger]'
               ]
             },
             'sources': []
@@ -2341,6 +2339,18 @@ describe('discipl-law-reg', () => {
                 '[aanvraag]'
               ],
               'fact': '[bedrag]'
+            },
+            'sources': []
+          },
+          {
+            'fact': '[burger with aanvraag]',
+            'explanation': '',
+            'function': {
+              'expression': 'PROJECTION',
+              'context': [
+                '[aanvraag]'
+              ],
+              'fact': '[burger]'
             },
             'sources': []
           },
@@ -2373,12 +2383,6 @@ describe('discipl-law-reg', () => {
             'explanation': '',
             'function': '[]',
             'sources': []
-          },
-          {
-            'fact': '[bsn]',
-            'explanation': '',
-            'function': '[]',
-            'sources': []
           }
         ],
         'duties': []
@@ -2405,11 +2409,11 @@ describe('discipl-law-reg', () => {
       }
 
       const availableActs1 = (await lawReg.getAvailableActsWithResolver(needLink, ssids['burger1'], factResolver)).map((actInfo) => actInfo.act)
-      expect(availableActs1).to.deep.equal([ '<<subsidie aanvragen>>' ])
+      expect(availableActs1).to.deep.equal(['<<subsidie aanvragen>>'])
 
       const actionLink = await lawReg.take(ssids['burger1'], needLink, '<<subsidie aanvragen>>', factResolver)
       const availableActs2 = (await lawReg.getAvailableActs(actionLink, ssids['burger1'])).map((actInfo) => actInfo.act)
-      expect(availableActs2).to.deep.equal([ '<<subsidie aanvraag intrekken>>' ])
+      expect(availableActs2).to.deep.equal(['<<subsidie aanvraag intrekken>>'])
 
       const burger2Acts = (await lawReg.getAvailableActs(actionLink, ssids['burger2'])).map((actInfo) => actInfo.act)
       expect(burger2Acts).to.deep.equal([])

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -898,65 +898,6 @@ describe('discipl-law-reg', () => {
       expect(errorMessage).to.equal('Unknown expression type')
     })
 
-    it('should reject an action when a fact defined with a "CREATE" epxression is supplied', async () => {
-      const core = lawReg.getAbundanceService().getCoreAPI()
-      const util = new Util(lawReg)
-      const { ssids, modelLink } = await util.setupModel({
-        'model': 'Fictieve kinderbijslag',
-        'acts': [
-          {
-            'act': '<<kinderbijslag aanvragen>>',
-            'actor': '[ouder]',
-            'object': '[verzoek]',
-            'recipient': '[Minister]',
-            'create': []
-          },
-          {
-            'act': '<<aanvraag kinderbijslag toekennen>>',
-            'actor': '[Minister]',
-            'object': '[aanvraag]',
-            'recipient': '[ouder]',
-            'preconditions': {
-              'expression': 'LITERAL',
-              'operand': true
-            }
-          }
-        ],
-        'facts': [
-          {
-            'fact': '[aanvraag]',
-            'function': { 'expression': 'CREATE' }
-          }
-        ],
-        'duties': []
-      }, ['ouder', 'minister'], { '[aanvraag]': 'supplied' })
-
-      const needLink = await core.claim(ssids['ouder'], {
-        'need': {
-          'act': '<<kinderbijslag aanvragen>>',
-          'DISCIPL_FLINT_MODEL_LINK': modelLink
-        }
-      })
-      const actionLink = await lawReg.take(ssids['ouder'], needLink, '<<kinderbijslag aanvragen>>', () => true)
-      const action = await core.get(actionLink, ssids['ouder'])
-      const needLink2 = await core.claim(ssids['minister'], {
-        'need': {
-          'act': '<<aanvraag kinderbijslag toekennen>>',
-          'DISCIPL_FLINT_MODEL_LINK': modelLink
-        },
-        ...action.data
-      })
-
-      let errorMessage = ''
-      try {
-        await lawReg.take(ssids['minister'], needLink2, '<<aanvraag kinderbijslag toekennen>>', () => true)
-      } catch (e) {
-        errorMessage = e.message
-      }
-
-      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
-    })
-
     it('should be able to determine active duties being terminated', async () => {
       const core = lawReg.getAbundanceService().getCoreAPI()
 
@@ -1071,7 +1012,7 @@ describe('discipl-law-reg', () => {
         'facts': [
           { 'fact': '[ingezetene]', 'function': '[]', 'reference': 'art 1.1' },
           { 'fact': '[overheid]', 'function': '[]', 'reference': '' },
-          { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE' }, 'reference': '' }
+          { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE', 'operands': [] }, 'reference': '' }
         ],
         'duties': [
         ]
@@ -1233,7 +1174,10 @@ describe('discipl-law-reg', () => {
         'facts': [
           {
             'fact': '[aanvraag]',
-            'function': { 'expression': 'CREATE' }
+            'function': {
+              'expression': 'CREATE',
+              'operands': []
+            }
           }
         ],
         'duties': []
@@ -1281,7 +1225,7 @@ describe('discipl-law-reg', () => {
         'facts': [
           { 'fact': '[ingezetene]', 'function': '[]', 'reference': 'art 1.1' },
           { 'fact': '[overheid]', 'function': '[]', 'reference': '' },
-          { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE' }, 'reference': '' }
+          { 'fact': '[verwelkomst]', 'function': { 'expression': 'CREATE', 'operands': [] }, 'reference': '' }
         ],
         'duties': [
         ]
@@ -1604,7 +1548,10 @@ describe('discipl-law-reg', () => {
         'facts': [
           {
             'fact': '[cookie]',
-            'function': { 'expression': 'CREATE' }
+            'function': {
+              'expression': 'CREATE',
+              'operands': []
+            }
           }
         ],
         'duties': []
@@ -1939,6 +1886,195 @@ describe('discipl-law-reg', () => {
         'value': '5'
       }
       )
+    })
+  })
+
+  describe('CREATE expression', async function () {
+    it('should take an action if the fact and operands are created', async () => {
+      const model = {
+        'acts': [
+          {
+            'act': '<<aanvraag kinderbijslag>>',
+            'actor': '[ouder]',
+            'recipient': '[minister]',
+            'object': '[verzoek]',
+            'create': [
+              '[aanvraag]'
+            ]
+          },
+          {
+            'act': '<<bedrag vaststellen>>',
+            'actor': '[ouder]',
+            'recipient': '[ouder]',
+            'object': '[bedrag]',
+            'create': [
+              '[bedrag]'
+            ]
+          },
+          {
+            'act': '<<aanvraag kinderbijslag toekennen>>',
+            'actor': '[minister]',
+            'object': '[aanvraag]',
+            'recipient': '[ouder]'
+          }
+        ],
+        'facts': [
+          {
+            'fact': '[aanvraag]',
+            'function': {
+              'expression': 'CREATE',
+              'operands': [
+                '[bedrag]'
+              ]
+            }
+          }
+        ],
+        'duties': []
+      }
+
+      const completeFacts = { '[ouder]': true, '[minister]': true, '[verzoek]': true, '[bedrag]': 100 }
+      const util = new Util(lawReg)
+
+      const { ssids, modelLink } = await util.setupModel(model, ['ouder', 'minister'], { 'ouder': '[ouder]', 'minister': '[minister]' })
+      const acts = [
+        {
+          'act': '<<bedrag vaststellen>>',
+          'actor': 'ouder'
+        },
+        {
+          'act': '<<aanvraag kinderbijslag>>',
+          'actor': 'ouder'
+        },
+        {
+          'act': '<<aanvraag kinderbijslag toekennen>>',
+          'actor': 'minister'
+        }
+      ]
+
+      let errorMessage = ''
+      try {
+        await util.scenarioTest(ssids, modelLink, acts, completeFacts)
+      } catch (e) {
+        errorMessage = e.message
+      }
+
+      expect(acts).to.deep.include({ 'act': '<<bedrag vaststellen>>', 'actor': 'ouder' })
+      expect(model.acts[0]).to.deep.include({ 'create': ['[aanvraag]'] })
+      expect(model.acts[1]).to.deep.include({ 'create': ['[bedrag]'] })
+      expect(errorMessage).to.equal('')
+    })
+
+    it('should not take an action if the fact is supplied', async () => {
+      const model = {
+        'acts': [
+          {
+            'act': '<<aanvraag kinderbijslag toekennen>>',
+            'actor': '[minister]',
+            'object': '[aanvraag]',
+            'recipient': '[ouder]'
+          }
+        ],
+        'facts': [
+          {
+            'fact': '[aanvraag]',
+            'function': {
+              'expression': 'CREATE',
+              'operands': []
+            }
+          }
+        ],
+        'duties': []
+      }
+
+      const completeFacts = { '[ouder]': true, '[minister]': true }
+      const util = new Util(lawReg)
+
+      const { ssids, modelLink } = await util.setupModel(model, ['minister'], { 'minister': '[minister]' })
+      const acts = [
+        {
+          'act': '<<aanvraag kinderbijslag toekennen>>',
+          'actor': 'minister'
+        }
+      ]
+
+      let errorMessage = ''
+      try {
+        await util.scenarioTest(ssids, modelLink, acts, completeFacts)
+      } catch (e) {
+        errorMessage = e.message
+      }
+
+      expect(model.acts[0]).to.not.deep.include({ 'create': ['[aanvraag]'] })
+      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
+    })
+
+    it('should not take an action if a fact given as operand is not given', async () => {
+      const model = {
+        'acts': [
+          {
+            'act': '<<bedrag vaststellen>>',
+            'actor': '[ouder]',
+            'recipient': '[ouder]',
+            'object': '[bedrag]',
+            'create': [
+              '[bedrag]'
+            ]
+          },
+          {
+            'act': '<<aanvraag kinderbijslag>>',
+            'actor': '[ouder]',
+            'recipient': '[minister]',
+            'object': '[verzoek]',
+            'create': [
+              '[aanvraag]'
+            ]
+          },
+          {
+            'act': '<<aanvraag kinderbijslag toekennen>>',
+            'actor': '[minister]',
+            'object': '[aanvraag]',
+            'recipient': '[ouder]'
+          }
+        ],
+        'facts': [
+          {
+            'fact': '[aanvraag]',
+            'function': {
+              'expression': 'CREATE',
+              'operands': [
+                '[bedrag]'
+              ]
+            }
+          }
+        ],
+        'duties': []
+      }
+
+      const completeFacts = { '[ouder]': true, '[minister]': true, '[verzoek]': true }
+      const util = new Util(lawReg)
+
+      const { ssids, modelLink } = await util.setupModel(model, ['ouder', 'minister'], { 'ouder': '[ouder]', 'minister': '[minister]' })
+      const acts = [
+        {
+          'act': '<<aanvraag kinderbijslag>>',
+          'actor': 'ouder'
+        },
+        {
+          'act': '<<aanvraag kinderbijslag toekennen>>',
+          'actor': 'minister'
+        }
+      ]
+
+      let errorMessage = ''
+      try {
+        await util.scenarioTest(ssids, modelLink, acts, completeFacts)
+      } catch (e) {
+        errorMessage = e.message
+      }
+
+      expect(Object.keys(completeFacts)).to.not.include('[bedrag]')
+      expect(acts).to.not.deep.include({ 'act': '<<bedrag vaststellen>>', 'actor': 'ouder' })
+      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
     })
   })
 })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -7,6 +7,7 @@ import * as log from 'loglevel'
 import Util from '../src/util'
 
 import awb from './flint-example-awb'
+import IdentityUtil from '../src/identity_util'
 
 // Adjusting log level for debugging can be done here, or in specific tests that need more finegrained logging during development
 log.getLogger('disciplLawReg').setLevel('debug')
@@ -200,7 +201,7 @@ describe('discipl-law-reg', () => {
         'DISCIPL_FLINT_FACTS_SUPPLIED': {
           '[overheid]': true,
           '[verwelkomst]': true,
-          '[ingezetene]': `IS:${ssids['ingezetene'].did}`
+          '[ingezetene]': IdentityUtil.identityExpression(ssids['ingezetene'].did)
         },
         'DISCIPL_FLINT_GLOBAL_CASE': needLink,
         'DISCIPL_FLINT_PREVIOUS_CASE': needLink
@@ -310,7 +311,7 @@ describe('discipl-law-reg', () => {
       expect(action.data).to.deep.equal({
         'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
         'DISCIPL_FLINT_FACTS_SUPPLIED': {
-          '[ingezetene]': `IS:${ssids['ingezetene1'].did}`,
+          '[ingezetene]': IdentityUtil.identityExpression(ssids['ingezetene1'].did),
           '[verwelkomst]': true
         },
         'DISCIPL_FLINT_GLOBAL_CASE': needLink,
@@ -354,8 +355,7 @@ describe('discipl-law-reg', () => {
       const actorSsid = await core.newSsid('ephemeral')
 
       const modelLink = await lawReg.publish(lawmakerSsid, model, {
-        '[ingezetene]':
-          'IS:' + actorSsid.did
+        '[ingezetene]': IdentityUtil.identityExpression(actorSsid.did)
       })
 
       const retrievedModel = await core.get(modelLink)
@@ -379,7 +379,7 @@ describe('discipl-law-reg', () => {
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
             '[overheid]': true,
             '[verwelkomst]': true,
-            '[ingezetene]': `IS:${actorSsid.did}`
+            '[ingezetene]': IdentityUtil.identityExpression(actorSsid.did)
           },
           'DISCIPL_FLINT_GLOBAL_CASE': needLink,
           'DISCIPL_FLINT_PREVIOUS_CASE': needLink
@@ -460,7 +460,7 @@ describe('discipl-law-reg', () => {
         'data': {
           'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
-            '[ouder]': `IS:${actorSsid.did}`,
+            '[ouder]': IdentityUtil.identityExpression(actorSsid.did),
             '[overheid]': true,
             '[verzoek]': true,
             'leeftijden': [
@@ -558,7 +558,7 @@ describe('discipl-law-reg', () => {
         'data': {
           'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
-            '[ouder]': `IS:${actorSsid.did}`,
+            '[ouder]': IdentityUtil.identityExpression(actorSsid.did),
             '[overheid]': true,
             '[verzoek]': true,
             'kinderen': [
@@ -666,9 +666,8 @@ describe('discipl-law-reg', () => {
       const overheidSsid = await core.newSsid('ephemeral')
 
       const modelLink = await lawReg.publish(lawmakerSsid, model, {
-        '[ingezetene]':
-          'IS:' + actorSsid.did,
-        '[overheid]': 'IS:' + overheidSsid.did
+        '[ingezetene]': IdentityUtil.identityExpression(actorSsid.did),
+        '[overheid]': IdentityUtil.identityExpression(overheidSsid.did)
       })
 
       const needLink = await core.claim(needSsid, {
@@ -722,287 +721,287 @@ describe('discipl-law-reg', () => {
 
     it('should be able to compare numbers', async () => {
       await testMathExpression({
-          'expression': 'LESS_THAN',
-          'operands': [
-            '[three]',
-            '[five]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5
-        })
+        'expression': 'LESS_THAN',
+        'operands': [
+          '[three]',
+          '[five]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5
+      })
     })
 
     it('should be able to compare literals', async () => {
       await testMathExpression({
-          'expression': 'LESS_THAN',
-          'operands': [
-            {
-              'expression': 'LITERAL',
-              'operand': 3
-            },
-            {
-              'expression': 'LITERAL',
-              'operand': 5
-            }
-          ]
-        },
-        {})
+        'expression': 'LESS_THAN',
+        'operands': [
+          {
+            'expression': 'LITERAL',
+            'operand': 3
+          },
+          {
+            'expression': 'LITERAL',
+            'operand': 5
+          }
+        ]
+      },
+      {})
     })
 
     it('should be able to compare numbers with a false result', async () => {
       await testFalseMathExpression({
-          'expression': 'LESS_THAN',
-          'operands': [
-            '[five]',
-            '[three]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5
-        })
+        'expression': 'LESS_THAN',
+        'operands': [
+          '[five]',
+          '[three]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5
+      })
     })
 
     it('should be able to compare numbers equality with a false result', async () => {
       await testFalseMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            '[dozen]',
-            '[thirteen]'
-          ]
-        },
-        {
-          '[dozen]': 12,
-          '[thirteen]': 13
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          '[dozen]',
+          '[thirteen]'
+        ]
+      },
+      {
+        '[dozen]': 12,
+        '[thirteen]': 13
+      })
     })
 
     it('should be able to add numbers', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'SUM',
-              'operands': [
-                '[three]', '[five]'
-              ]
-            },
-            '[eight]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5,
-          '[eight]': 8
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'SUM',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          '[eight]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5,
+        '[eight]': 8
+      })
     })
 
     it('should be able to add in a list', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'SUM',
-              'operands': [
-                {
-                  'expression': 'LIST',
-                  'items': '[number]'
-                }
-              ]
-            },
-            '[eight]'
-          ]
-        },
-        {
-          '[number]': [3, 5, false],
-          '[eight]': 8
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'SUM',
+            'operands': [
+              {
+                'expression': 'LIST',
+                'items': '[number]'
+              }
+            ]
+          },
+          '[eight]'
+        ]
+      },
+      {
+        '[number]': [3, 5, false],
+        '[eight]': 8
+      })
     })
 
     it('should be able to add numbers with a false result', async () => {
       await testFalseMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'SUM',
-              'operands': [
-                '[three]', '[five]'
-              ]
-            },
-            '[nine]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5,
-          '[nine]': 9
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'SUM',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          '[nine]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5,
+        '[nine]': 9
+      })
     })
 
     it('should be able to determine the minimum of numbers', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'MIN',
-              'operands': [
-                '[three]', '[five]'
-              ]
-            },
-            '[three]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'MIN',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          '[three]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5
+      })
     })
 
     it('should be able to evaluate a literal boolean', async () => {
       await testMathExpression({
-          'expression': 'LITERAL',
-          'operand': true
-        },
-        {})
+        'expression': 'LITERAL',
+        'operand': true
+      },
+      {})
     })
 
     it('should be able to determine the minimum of numbers', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'MIN',
-              'operands': [
-                '[three]', '[five]'
-              ]
-            },
-            '[three]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'MIN',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          '[three]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5
+      })
     })
 
     it('should be able to multiply in a list', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'PRODUCT',
-              'operands': [
-                {
-                  'expression': 'LIST',
-                  'items': '[number]'
-                }
-              ]
-            },
-            '[fifteen]'
-          ]
-        },
-        {
-          '[number]': [3, 5, false],
-          '[fifteen]': 15
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'PRODUCT',
+            'operands': [
+              {
+                'expression': 'LIST',
+                'items': '[number]'
+              }
+            ]
+          },
+          '[fifteen]'
+        ]
+      },
+      {
+        '[number]': [3, 5, false],
+        '[fifteen]': 15
+      })
     })
 
     it('should be able to multiply numbers with arbitrary precision', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'PRODUCT',
-              'operands': [
-                {
-                  'expression': 'LITERAL',
-                  'operand': 1.15
-                }, '[400]', '[100]'
-              ]
-            },
-            '[46000]'
-          ]
-        },
-        {
-          '[400]': 400,
-          '[100]': 100,
-          '[46000]': 46000
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'PRODUCT',
+            'operands': [
+              {
+                'expression': 'LITERAL',
+                'operand': 1.15
+              }, '[400]', '[100]'
+            ]
+          },
+          '[46000]'
+        ]
+      },
+      {
+        '[400]': 400,
+        '[100]': 100,
+        '[46000]': 46000
+      })
     })
 
     it('should be able to multiply numbers with a false result', async () => {
       await testFalseMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'PRODUCT',
-              'operands': [
-                '[three]', '[five]'
-              ]
-            },
-            '[fourteen]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5,
-          '[fourteen]': 14
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'PRODUCT',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          '[fourteen]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5,
+        '[fourteen]': 14
+      })
     })
 
     it('should be able to determine the maximum of numbers', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'MAX',
-              'operands': [
-                '[three]', '[five]'
-              ]
-            },
-            '[five]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'MAX',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          '[five]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5
+      })
     })
 
     it('should be able to determine the minimum of numbers', async () => {
       await testMathExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'MIN',
-              'operands': [
-                '[three]', '[five]'
-              ]
-            },
-            '[three]'
-          ]
-        },
-        {
-          '[three]': 3,
-          '[five]': 5
-        })
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'MIN',
+            'operands': [
+              '[three]', '[five]'
+            ]
+          },
+          '[three]'
+        ]
+      },
+      {
+        '[three]': 3,
+        '[five]': 5
+      })
     })
 
     it('should throw an error with unknown expressions', async () => {
       let errorMessage
       try {
         await testMathExpression({
-            'expression': 'BANANAS',
-            'operands': [
-              '[three]', '[five]'
-            ]
-          },
-          {
-            '[three]': 3,
-            '[five]': 5
-          })
+          'expression': 'BANANAS',
+          'operands': [
+            '[three]', '[five]'
+          ]
+        },
+        {
+          '[three]': 3,
+          '[five]': 5
+        })
       } catch (e) {
         errorMessage = e.message
       }
@@ -1140,9 +1139,8 @@ describe('discipl-law-reg', () => {
       const overheidSsid = await core.newSsid('ephemeral')
 
       const modelLink = await lawReg.publish(lawmakerSsid, model, {
-        '[ingezetene]':
-          'IS:' + ingezeteneSsid.did,
-        '[overheid]': 'IS:' + overheidSsid.did
+        '[ingezetene]': IdentityUtil.identityExpression(ingezeteneSsid.did),
+        '[overheid]': IdentityUtil.identityExpression(overheidSsid.did)
       })
 
       const needLink = await core.claim(needSsid, {
@@ -1379,8 +1377,7 @@ describe('discipl-law-reg', () => {
       const actorSsid = await core.newSsid('ephemeral')
 
       const modelLink = await lawReg.publish(lawmakerSsid, { ...awb, 'model': 'AWB' }, {
-        '[persoon wiens belang rechtstreeks bij een besluit is betrokken]':
-          'IS:' + actorSsid.did
+        '[persoon wiens belang rechtstreeks bij een besluit is betrokken]': IdentityUtil.identityExpression(actorSsid.did)
       })
 
       const retrievedModel = await core.get(modelLink)
@@ -1411,7 +1408,7 @@ describe('discipl-law-reg', () => {
         'data': {
           'DISCIPL_FLINT_ACT_TAKEN': Object.values(retrievedModel.data['DISCIPL_FLINT_MODEL'].acts[0])[0],
           'DISCIPL_FLINT_FACTS_SUPPLIED': {
-            '[belanghebbende]': `IS:${actorSsid.did}`,
+            '[belanghebbende]': IdentityUtil.identityExpression(actorSsid.did),
             '[bij wettelijk voorschrift is anders bepaald]': false,
             '[verzoek een besluit te nemen]': true,
             '[wetgevende macht]': true
@@ -1435,10 +1432,8 @@ describe('discipl-law-reg', () => {
       await core.allow(bestuursorgaanSsid)
 
       const modelLink = await lawReg.publish(lawmakerSsid, { ...awb, 'model': 'AWB' }, {
-        '[persoon wiens belang rechtstreeks bij een besluit is betrokken]':
-          'IS:' + belanghebbendeSsid.did,
-        '[wetgevende macht]':
-          'IS:' + bestuursorgaanSsid.did
+        '[persoon wiens belang rechtstreeks bij een besluit is betrokken]': IdentityUtil.identityExpression(belanghebbendeSsid.did),
+        '[wetgevende macht]': IdentityUtil.identityExpression(bestuursorgaanSsid.did)
       })
 
       const retrievedModel = await core.get(modelLink)
@@ -1479,12 +1474,12 @@ describe('discipl-law-reg', () => {
       const action = await core.get(secondActionLink, bestuursorgaanSsid)
 
       const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-      .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
+        .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
 
       expect(action.data).to.deep.equal({
         'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
         'DISCIPL_FLINT_FACTS_SUPPLIED': {
-          '[bestuursorgaan]': `IS:${bestuursorgaanSsid.did}`,
+          '[bestuursorgaan]': IdentityUtil.identityExpression(bestuursorgaanSsid.did),
           '[aanvraag]': actionLink,
           '[aanvraag is geheel of gedeeltelijk geweigerd op grond van artikel 2:15 Awb]': true
         },
@@ -1695,7 +1690,7 @@ describe('discipl-law-reg', () => {
       const eatDetails = await core.get(eatAction, ssids['baker'])
 
       expect(eatDetails.data['DISCIPL_FLINT_FACTS_SUPPLIED']).to.deep.equal({
-        '[baker]': `IS:${ssids['baker'].did}`,
+        '[baker]': IdentityUtil.identityExpression(ssids['baker'].did),
         '[bakery]': true,
         '[cookie]': firstBakeAction
       })
@@ -1705,7 +1700,7 @@ describe('discipl-law-reg', () => {
       const eatDetails2 = await core.get(eatAction2, ssids['baker'])
 
       expect(eatDetails2.data['DISCIPL_FLINT_FACTS_SUPPLIED']).to.deep.equal({
-        '[baker]': `IS:${ssids['baker'].did}`,
+        '[baker]': IdentityUtil.identityExpression(ssids['baker'].did),
         '[bakery]': true,
         '[cookie]': secondBakeAction
       })
@@ -1770,8 +1765,7 @@ describe('discipl-law-reg', () => {
 
       const ssid = await core.newSsid('ephemeral')
       const modelLink = await lawReg.publish(ssid, model, {
-        '[aanvrager]':
-          'IS:' + ssid.did
+        '[aanvrager]': IdentityUtil.identityExpression(ssid.did)
       })
       const modelRef = await core.get(modelLink, ssid)
 
@@ -1799,8 +1793,7 @@ describe('discipl-law-reg', () => {
 
       const ssid = await core.newSsid('ephemeral')
       const modelLink = await lawReg.publish(ssid, model, {
-        '[aanvrager]':
-          'IS:' + ssid.did
+        '[aanvrager]': IdentityUtil.identityExpression(ssid.did)
       })
       const modelRef = await core.get(modelLink, ssid)
 
@@ -1879,119 +1872,119 @@ describe('discipl-law-reg', () => {
 
     it('should be able to explain an expression', async () => {
       await explainExpression({
-          'expression': 'EQUAL',
-          'operands': [
-            {
-              'expression': 'LITERAL',
-              'operand': 'banana'
-            },
-            '[favourite meal]'
-          ]
-        },
-        {
-          '[favourite meal]': 'banana'
-        },
-        {
-          'fact': '[expression]',
-          'operandExplanations': [
-            {
-              'expression': 'EQUAL',
-              'operandExplanations': [
-                {
-                  'expression': 'LITERAL',
-                  'value': 'banana'
-                },
-                {
-                  'fact': '[favourite meal]',
-                  'operandExplanations': [
-                    {
-                      'value': 'banana'
-                    }
-                  ],
-                  'value': 'banana'
-                }
-              ],
-              'value': true
-            }
-          ],
-          'value': true
-        }
+        'expression': 'EQUAL',
+        'operands': [
+          {
+            'expression': 'LITERAL',
+            'operand': 'banana'
+          },
+          '[favourite meal]'
+        ]
+      },
+      {
+        '[favourite meal]': 'banana'
+      },
+      {
+        'fact': '[expression]',
+        'operandExplanations': [
+          {
+            'expression': 'EQUAL',
+            'operandExplanations': [
+              {
+                'expression': 'LITERAL',
+                'value': 'banana'
+              },
+              {
+                'fact': '[favourite meal]',
+                'operandExplanations': [
+                  {
+                    'value': 'banana'
+                  }
+                ],
+                'value': 'banana'
+              }
+            ],
+            'value': true
+          }
+        ],
+        'value': true
+      }
       )
     })
 
     it('should be able to explain a less-than expression', async () => {
       await explainExpression({
-          'expression': 'LESS_THAN',
-          'operands': [
-            {
-              'expression': 'LITERAL',
-              'operand': 5
-            },
-            {
-              'expression': 'LITERAL',
-              'operand': 6
-            }
-          ]
-        },
-        {},
-        {
-          'fact': '[expression]',
-          'operandExplanations': [
-            {
-              'expression': 'LESS_THAN',
-              'operandExplanations': [
-                {
-                  'expression': 'LITERAL',
-                  'value': '5'
-                },
-                {
-                  'expression': 'LITERAL',
-                  'value': '6'
-                }
-              ],
-              'value': true
-            }
-          ],
-          'value': true
-        }
+        'expression': 'LESS_THAN',
+        'operands': [
+          {
+            'expression': 'LITERAL',
+            'operand': 5
+          },
+          {
+            'expression': 'LITERAL',
+            'operand': 6
+          }
+        ]
+      },
+      {},
+      {
+        'fact': '[expression]',
+        'operandExplanations': [
+          {
+            'expression': 'LESS_THAN',
+            'operandExplanations': [
+              {
+                'expression': 'LITERAL',
+                'value': '5'
+              },
+              {
+                'expression': 'LITERAL',
+                'value': '6'
+              }
+            ],
+            'value': true
+          }
+        ],
+        'value': true
+      }
       )
     })
 
     it('should be able to explain a min expression', async () => {
       await explainExpression({
-          'expression': 'MIN',
-          'operands': [
-            {
-              'expression': 'LITERAL',
-              'operand': 5
-            },
-            {
-              'expression': 'LITERAL',
-              'operand': 6
-            }
-          ]
-        },
-        {},
-        {
-          'fact': '[expression]',
-          'operandExplanations': [
-            {
-              'expression': 'MIN',
-              'operandExplanations': [
-                {
-                  'expression': 'LITERAL',
-                  'value': '5'
-                },
-                {
-                  'expression': 'LITERAL',
-                  'value': '6'
-                }
-              ],
-              'value': '5'
-            }
-          ],
-          'value': '5'
-        }
+        'expression': 'MIN',
+        'operands': [
+          {
+            'expression': 'LITERAL',
+            'operand': 5
+          },
+          {
+            'expression': 'LITERAL',
+            'operand': 6
+          }
+        ]
+      },
+      {},
+      {
+        'fact': '[expression]',
+        'operandExplanations': [
+          {
+            'expression': 'MIN',
+            'operandExplanations': [
+              {
+                'expression': 'LITERAL',
+                'value': '5'
+              },
+              {
+                'expression': 'LITERAL',
+                'value': '6'
+              }
+            ],
+            'value': '5'
+          }
+        ],
+        'value': '5'
+      }
       )
     })
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1978,8 +1978,7 @@ describe('discipl-law-reg', () => {
           {
             'fact': '[aanvraag]',
             'function': {
-              'expression': 'CREATE',
-              'operands': []
+              'expression': 'CREATE'
             }
           }
         ],
@@ -2078,7 +2077,7 @@ describe('discipl-law-reg', () => {
     })
   })
 
-  describe.only('PROJECTION expression', async function () {
+  describe('PROJECTION expression', async function () {
     it('should get the projected property', async () => {
       const model = {
         'acts': [
@@ -2087,12 +2086,7 @@ describe('discipl-law-reg', () => {
             'actor': '[burger]',
             'recipient': '[ambtenaar]',
             'object': '[verzoek]',
-            'preconditions': {
-              'expression': 'AND',
-              'operands': [
-                '[bedrag]'
-              ]
-            },
+            'preconditions': '[bedrag]',
             'create': [
               '[aanvraag]'
             ]
@@ -2168,12 +2162,7 @@ describe('discipl-law-reg', () => {
             'actor': '[burger]',
             'recipient': '[ambtenaar]',
             'object': '[verzoek]',
-            'preconditions': {
-              'expression': 'AND',
-              'operands': [
-                '[naam]'
-              ]
-            },
+            'preconditions': '[naam]',
             'create': [
               '[persoonlijke gegevens]'
             ]

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -779,14 +779,14 @@ describe('discipl-law-reg', () => {
       await util.scenarioTest(ssids, modelLink, [{ 'act': '<<compute mathematical expression>>', 'actor': 'mathematician' }], completeFacts)
     }
 
-    const testFalseMathExpression = async (precondition, facts) => {
+    const testFalseMathExpression = async (precondition, facts, reason) => {
       let errorMessage = ''
       try {
         await testMathExpression(precondition, facts)
       } catch (e) {
         errorMessage = e.message
       }
-      expect(errorMessage).to.equal('Action <<compute mathematical expression>> is not allowed')
+      expect(errorMessage).to.equal('Action <<compute mathematical expression>> is not allowed ' + reason)
     }
 
     it('should be able to compare numbers', async () => {
@@ -831,7 +831,9 @@ describe('discipl-law-reg', () => {
       {
         '[three]': 3,
         '[five]': 5
-      })
+      },
+      'due to preconditions'
+      )
     })
 
     it('should be able to compare numbers equality with a false result', async () => {
@@ -845,7 +847,9 @@ describe('discipl-law-reg', () => {
       {
         '[dozen]': 12,
         '[thirteen]': 13
-      })
+      },
+      'due to preconditions'
+      )
     })
 
     it('should be able to add numbers', async () => {
@@ -907,7 +911,9 @@ describe('discipl-law-reg', () => {
         '[three]': 3,
         '[five]': 5,
         '[nine]': 9
-      })
+      },
+      'due to preconditions'
+      )
     })
 
     it('should be able to determine the minimum of numbers', async () => {
@@ -1018,7 +1024,9 @@ describe('discipl-law-reg', () => {
         '[three]': 3,
         '[five]': 5,
         '[fourteen]': 14
-      })
+      },
+      'due to preconditions'
+      )
     })
 
     it('should be able to determine the maximum of numbers', async () => {
@@ -2174,7 +2182,7 @@ describe('discipl-law-reg', () => {
       }
 
       expect(model.acts[0]).to.not.deep.include({ 'create': ['[aanvraag]'] })
-      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
+      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed due to object')
     })
 
     it('should not take an action if a fact given as operand is not given', async () => {
@@ -2243,7 +2251,7 @@ describe('discipl-law-reg', () => {
 
       expect(Object.keys(completeFacts)).to.not.include('[bedrag]')
       expect(acts).to.not.deep.include({ 'act': '<<bedrag vaststellen>>', 'actor': 'ouder' })
-      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed')
+      expect(errorMessage).to.equal('Action <<aanvraag kinderbijslag toekennen>> is not allowed due to object')
     })
 
     it('should allow OR expressions', async () => {
@@ -2851,7 +2859,7 @@ describe('discipl-law-reg', () => {
       }
 
       expect(completeFacts).to.deep.include({ '[bedrag]': 500 })
-      expect(errorMessage).to.equal('Action <<subsidie aanvraag toekennen>> is not allowed')
+      expect(errorMessage).to.equal('Action <<subsidie aanvraag toekennen>> is not allowed due to object')
     })
 
     it('should be able to take an action after object is created from other action', async () => {

--- a/test/lerarenbeurs-scenarios.spec.js
+++ b/test/lerarenbeurs-scenarios.spec.js
@@ -5,6 +5,7 @@ import * as log from 'loglevel'
 import Util from './../src/util'
 
 import lb from './flint-example-lerarenbeurs'
+import IdentityUtil from '../src/identity_util'
 
 // Adjusting log level for debugging can be done here, or in specific tests that need more finegrained logging during development
 log.getLogger('disciplLawReg').setLevel('warn')
@@ -92,9 +93,9 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(action.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
         '[aanvraag]': actionLink,
+        '[bestuursorgaan]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
         '[aanvrager heeft de gelegenheid gehad de aanvraag aan te vullen]': true,
         '[aanvrager heeft voldaan aan enig wettelijk voorschrift voor het in behandeling nemen van de aanvraag]': false,
         '[de aanvraag is binnen de afgelopen 4 weken aangevuld]': true
@@ -266,8 +267,8 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(action.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
+        '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
         '[aanvraag]': actionLink2,
         '[budget volledig benut]': false,
         '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]': true,
@@ -353,8 +354,8 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(thirdAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedThirdActLink[0])[0],
-      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['belanghebbende'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
+        '[leraar]': IdentityUtil.identityExpression(ssids['belanghebbende'].did),
         '[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]': actionLink,
         '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]': true,
         '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]': true
@@ -365,8 +366,8 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(lastAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
+        '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
         '[hoogte van de subsidie voor studiekosten]': true
       },
       'DISCIPL_FLINT_GLOBAL_CASE': needLink,
@@ -433,8 +434,8 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(lastAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['belanghebbende'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
+        '[leraar]': IdentityUtil.identityExpression(ssids['belanghebbende'].did),
         '[aanvraag subsidie voor studiekosten]': actionLink2,
         '[binnen twee maanden na het verstrekken van de subsidie]': true
       },
@@ -501,8 +502,8 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(lastAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
+        '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
         '[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]': actionLink3,
         '[subsidieverlening aan een leraar]': true
       },

--- a/test/lerarenbeurs-scenarios.spec.js
+++ b/test/lerarenbeurs-scenarios.spec.js
@@ -8,561 +8,755 @@ import lb from './flint-example-lerarenbeurs'
 import IdentityUtil from '../src/identity_util'
 
 // Adjusting log level for debugging can be done here, or in specific tests that need more finegrained logging during development
-log.getLogger('disciplLawReg').setLevel('warn')
+log.getLogger('disciplLawReg').setLevel('debug')
 
 const lawReg = new LawReg()
 const core = lawReg.getAbundanceService().getCoreAPI()
 
-const factFunctionSpec = {
-  '[persoon wiens belang rechtstreeks bij een besluit is betrokken]': 'belanghebbende',
-  '[degene die voldoet aan bevoegdheidseisen gesteld in]': 'belanghebbende',
-  '[artikel 3 van de Wet op het primair onderwijs]': 'belanghebbende',
-  '[artikel 3 van de Wet op de expertisecentra]': 'belanghebbende',
-  '[artikel XI van de Wet op de beroepen in het onderwijs]': 'belanghebbende',
-  '[artikel 3 van de Wet primair onderwijs BES]': 'belanghebbende',
-  '[is benoemd of tewerkgesteld zonder benoeming als bedoeld in artikel 33 van de Wet op het voortgezet onderwijs]': 'belanghebbende',
-  '[artikel 4.2.1. van de Wet educatie en beroepsonderwijs]': 'belanghebbende',
-  '[artikel 80 van de Wet voortgezet onderwijs BES]': 'belanghebbende',
-  '[artikel 4.2.1 van de Wet educatie beroepsonderwijs BES]': 'belanghebbende',
-  '[die lesgeeft in het hoger onderwijs]': 'belanghebbende',
-  '[orgaan]': 'bestuursorgaan',
-  '[rechtspersoon die krachtens publiekrecht is ingesteld]': 'bestuursorgaan',
-  '[met enig openbaar gezag bekleed]': 'bestuursorgaan',
-  '[artikel 1 van de Wet op het primair onderwijs]': 'bevoegdGezag',
-  '[artikel 1 van de Wet op de expertisecentra]': 'bevoegdGezag',
-  '[artikel 1 van de Wet op het voortgezet onderwijs]': 'bevoegdGezag',
-  '[artikel 1.1.1., onderdeel w, van de Wet educatie en beroepsonderwijs]': 'bevoegdGezag',
-  '[artikel 1 van de Wet primair onderwijs BES]': 'bevoegdGezag',
-  '[artikel 1 van de Wet voortgezet onderwijs BES]': 'bevoegdGezag',
-  '[artikel 1.1.1, van de Wet educatie en beroepsonderwijs BES]': 'bevoegdGezag',
-  '[instellingsbestuur bedoeld in artikel 1.1, onderdeel j, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek]': 'bevoegdGezag',
-  '[minister van Onderwijs, Cultuur en Wetenschap]': 'bestuursorgaan',
-  '[persoon]': 'ANYONE'
-}
-
-const setupModel = async () => {
-  const util = new Util(lawReg)
-  return util.setupModel(lb, ['belanghebbende', 'bestuursorgaan', 'bevoegdGezag'], factFunctionSpec)
-}
-
 let ssids, modelLink
 
 describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
-  before(async () => {
-    ({ ssids, modelLink } = await setupModel())
+  describe('without mutliple same type actors', () => {
+    const factFunctionSpec = {
+      '[persoon wiens belang rechtstreeks bij een besluit is betrokken]': 'belanghebbende',
+      '[degene die voldoet aan bevoegdheidseisen gesteld in]': 'belanghebbende',
+      '[artikel 3 van de Wet op het primair onderwijs]': 'belanghebbende',
+      '[artikel 3 van de Wet op de expertisecentra]': 'belanghebbende',
+      '[artikel XI van de Wet op de beroepen in het onderwijs]': 'belanghebbende',
+      '[artikel 3 van de Wet primair onderwijs BES]': 'belanghebbende',
+      '[is benoemd of tewerkgesteld zonder benoeming als bedoeld in artikel 33 van de Wet op het voortgezet onderwijs]': 'belanghebbende',
+      '[artikel 4.2.1. van de Wet educatie en beroepsonderwijs]': 'belanghebbende',
+      '[artikel 80 van de Wet voortgezet onderwijs BES]': 'belanghebbende',
+      '[artikel 4.2.1 van de Wet educatie beroepsonderwijs BES]': 'belanghebbende',
+      '[die lesgeeft in het hoger onderwijs]': 'belanghebbende',
+      '[orgaan]': 'bestuursorgaan',
+      '[rechtspersoon die krachtens publiekrecht is ingesteld]': 'bestuursorgaan',
+      '[met enig openbaar gezag bekleed]': 'bestuursorgaan',
+      '[artikel 1 van de Wet op het primair onderwijs]': 'bevoegdGezag',
+      '[artikel 1 van de Wet op de expertisecentra]': 'bevoegdGezag',
+      '[artikel 1 van de Wet op het voortgezet onderwijs]': 'bevoegdGezag',
+      '[artikel 1.1.1., onderdeel w, van de Wet educatie en beroepsonderwijs]': 'bevoegdGezag',
+      '[artikel 1 van de Wet primair onderwijs BES]': 'bevoegdGezag',
+      '[artikel 1 van de Wet voortgezet onderwijs BES]': 'bevoegdGezag',
+      '[artikel 1.1.1, van de Wet educatie en beroepsonderwijs BES]': 'bevoegdGezag',
+      '[instellingsbestuur bedoeld in artikel 1.1, onderdeel j, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek]': 'bevoegdGezag',
+      '[minister van Onderwijs, Cultuur en Wetenschap]': 'bestuursorgaan',
+      '[persoon]': 'ANYONE'
+    }
+    const setupModel = async () => {
+      const util = new Util(lawReg)
+      return util.setupModel(lb, ['belanghebbende', 'bestuursorgaan', 'bevoegdGezag'], factFunctionSpec)
+    }
+    before(async () => {
+      ({ ssids, modelLink } = await setupModel())
+    })
+    it('should be able to take an action where the object originates from another action - LERARENBEURS', async () => {
+      const retrievedModel = await core.get(modelLink)
+
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<indienen verzoek een besluit te nemen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const belanghebbendeFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[verzoek een besluit te nemen]'
+        }
+        return false
+      }
+
+      const actionLink = await lawReg.take(ssids['belanghebbende'], needLink, '<<indienen verzoek een besluit te nemen>>', belanghebbendeFactresolver)
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[persoon wiens belang rechtstreeks bij een besluit is betrokken]' ||
+            fact === '[aanvrager heeft de gelegenheid gehad de aanvraag aan te vullen]' ||
+            fact === '[de aanvraag is binnen de afgelopen 4 weken aangevuld]'
+        }
+        return false
+      }
+
+      const secondActionLink = await lawReg.take(ssids['bestuursorgaan'], actionLink, '<<besluiten de aanvraag niet te behandelen>>', bestuursorgaanFactresolver)
+
+      expect(secondActionLink).to.be.a('string')
+
+      const action = await core.get(secondActionLink, ssids['bestuursorgaan'])
+
+      const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
+
+      expect(action.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[aanvraag]': actionLink,
+          '[bestuursorgaan]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
+          '[aanvrager heeft de gelegenheid gehad de aanvraag aan te vullen]': true,
+          '[aanvrager heeft voldaan aan enig wettelijk voorschrift voor het in behandeling nemen van de aanvraag]': false,
+          '[de aanvraag is binnen de afgelopen 4 weken aangevuld]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink
+      })
+
+      const takenActs = await lawReg.getActions(secondActionLink, ssids['belanghebbende'])
+      expect(takenActs).to.deep.equal([{ 'act': '<<indienen verzoek een besluit te nemen>>', 'link': actionLink }, { 'act': '<<besluiten de aanvraag niet te behandelen>>', 'link': secondActionLink }])
+    }).timeout(5000)
+
+    it('should be able to determine available actions', async () => {
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<indienen verzoek een besluit te nemen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const allowedActs = await lawReg.getAvailableActs(needLink, ssids['belanghebbende'], ['[verzoek een besluit te nemen]'], ['[bij wettelijk voorschrift is anders bepaald]'])
+
+      const allowedActNames = allowedActs.map((act) => act.act)
+
+      expect(allowedActNames).to.deep.equal(['<<indienen verzoek een besluit te nemen>>'])
+    }).timeout(10000)
+
+    it('should be able to determine available actions with nonfacts', async () => {
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<indienen verzoek een besluit te nemen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const allowedActs = await lawReg.getAvailableActs(needLink, ssids['belanghebbende'], [], ['[verzoek een besluit te nemen]'])
+
+      const allowedActNames = allowedActs.map((act) => act.act)
+
+      expect(allowedActNames).to.deep.equal([])
+    }).timeout(10000)
+
+    it('should be able to determine potentially available actions', async () => {
+      const { ssids, modelLink } = await setupModel()
+
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<indienen verzoek een besluit te nemen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const allowedActs = await lawReg.getPotentialActs(needLink, ssids['belanghebbende'], [])
+
+      const allowedActNames = allowedActs.map((act) => act.act)
+
+      expect(allowedActNames).to.deep.equal([
+        '<<indienen verzoek een besluit te nemen>>'
+      ])
+    }).timeout(10000)
+
+    it('should be able to determine potentially available actions with non-facts', async () => {
+      const { ssids, modelLink } = await setupModel()
+
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<indienen verzoek een besluit te nemen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const allowedActs = await lawReg.getPotentialActs(needLink, ssids['belanghebbende'], [], ['[verzoek een besluit te nemen]'])
+
+      const allowedActNames = allowedActs.map((act) => act.act)
+
+      expect(allowedActNames).to.deep.equal([])
+    }).timeout(10000)
+
+    it('should be able to determine potentially available actions from another perspective', async () => {
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<indienen verzoek een besluit te nemen>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const allowedActs = await lawReg.getPotentialActs(needLink, ssids['bestuursorgaan'], [])
+
+      const allowedActNames = allowedActs.map((act) => act.act)
+
+      expect(allowedActNames).to.deep.equal([
+        '<<vaststellen formulier voor verstrekken van gegevens>>',
+        '<<minister treft betalingsregeling voor het terugbetalen van de subsidie voor studiekosten>>',
+        '<<minister laat een of meer bepalingen van de subsidieregeling lerarenbeurs buiten toepassing>>',
+        '<<minister wijkt af van een of meer bepalingen van de subsidieregeling lerarenbeurs>>',
+        '<<minister van OCW verdeelt het beschikbare bedrag voor de subsidieregeling lerarenbeurs per doelgroep>>',
+        '<<minister van OCW verdeelt concreet het beschikbare budget in een studiejaar per soort onderwijs>>',
+        '<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>',
+        '<<minister van OCW berekent de hoogte van de subsidie voor studieverlof>>',
+        '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>',
+        '<<aanvraagformulieren verstrekken voor subsidie studieverlof op de website van de DUO>>'
+      ])
+    }).timeout(10000)
+
+    it('should perform multiple acts for a happy flow in the context of Lerarenbeurs', async () => {
+      const retrievedModel = await core.get(modelLink)
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<leraar vraagt subsidie voor studiekosten aan>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const belanghebbendeFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[subsidie voor studiekosten]' ||
+            fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]'
+        }
+        return false
+      }
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[subsidie lerarenbeurs]' ||
+            fact === '[subsidie voor bacheloropleiding leraar]' ||
+            fact === '[leraar voldoet aan bevoegdheidseisen]' ||
+            fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
+            fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
+            fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
+            fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
+            fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
+            fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
+            fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
+            fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
+            fact === '[template voor aanvraagformulieren studiekosten]'
+        }
+        return false
+      }
+
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
+
+      const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
+
+      const actionLink3 = await lawReg.take(ssids['bestuursorgaan'], actionLink2, '<<minister verstrekt subsidie lerarenbeurs aan leraar>>', bestuursorgaanFactresolver)
+
+      const action = await core.get(actionLink3, ssids['bestuursorgaan'])
+
+      const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<minister verstrekt subsidie lerarenbeurs aan leraar>>'))
+
+      expect(action.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
+          '[aanvraag]': actionLink2,
+          '[budget volledig benut]': false,
+          '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]': true,
+          '[leraar die ingeschreven staat in registerleraar.nl]': true,
+          '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]': true,
+          '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]': true,
+          '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]': true,
+          '[leraar is aangesteld als ambulant begeleider]': false,
+          '[leraar is aangesteld als intern begeleider]': false,
+          '[leraar is aangesteld als remedial teacher]': false,
+          '[leraar is aangesteld als zorgcoördinator]': false,
+          '[leraar ontvangt van de minister een tegemoetkoming in de studiekosten voor het volgen van de opleiding]': false,
+          '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]': true,
+          '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]': true,
+          '[subsidie lerarenbeurs]': true,
+          '[subsidie voor bacheloropleiding leraar]': true,
+          '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink2
+      })
+    }).timeout(5000)
+
+    it('should perform an extended happy flow in the context of Lerarenbeurs', async () => {
+      const retrievedModel = await core.get(modelLink)
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
+            fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
+            fact === '[subsidie lerarenbeurs]' ||
+            fact === '[subsidie voor bacheloropleiding leraar]' ||
+            fact === '[leraar voldoet aan bevoegdheidseisen]' ||
+            fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
+            fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
+            fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
+            fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
+            fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
+            fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
+            fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
+            fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
+            fact === '[hoogte van de subsidie voor studiekosten]' ||
+            fact === '[template voor aanvraagformulieren studiekosten]'
+        }
+        return false
+      }
+
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
+
+      const belanghebbendeFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[inleveren]' ||
+            fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]'
+        }
+        return false
+      }
+
+      const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
+      const actionLink3 = await lawReg.take(ssids['bestuursorgaan'], actionLink2, '<<minister verstrekt subsidie lerarenbeurs aan leraar>>', bestuursorgaanFactresolver)
+      const actionLink4 = await lawReg.take(ssids['bestuursorgaan'], actionLink3, '<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>', bestuursorgaanFactresolver)
+
+      const thirdAction = await core.get(actionLink2, ssids['bestuursorgaan'])
+
+      const expectedThirdActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<leraar vraagt subsidie voor studiekosten aan>>'))
+
+      const lastAction = await core.get(actionLink4, ssids['bestuursorgaan'])
+
+      const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>'))
+
+      expect(thirdAction.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedThirdActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[leraar]': IdentityUtil.identityExpression(ssids['belanghebbende'].did),
+          '[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]': actionLink,
+          '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]': true,
+          '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink
+      })
+
+      expect(lastAction.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
+          '[hoogte van de subsidie voor studiekosten]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink3
+      })
+    }).timeout(5000)
+
+    it('should perform an extended flow where teacher withdraws request in the context of Lerarenbeurs', async () => {
+      const retrievedModel = await core.get(modelLink)
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
+            fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
+            fact === '[subsidie lerarenbeurs]' ||
+            fact === '[subsidie voor bacheloropleiding leraar]' ||
+            fact === '[leraar voldoet aan bevoegdheidseisen]' ||
+            fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
+            fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
+            fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
+            fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
+            fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
+            fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
+            fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
+            fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
+            fact === '[hoogte van de subsidie voor studiekosten]' ||
+            fact === '[template voor aanvraagformulieren studiekosten]'
+        }
+        return false
+      }
+
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
+
+      const belanghebbendeFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[inleveren]' ||
+            fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]' ||
+            fact === '[binnen twee maanden na het verstrekken van de subsidie]'
+        }
+        return false
+      }
+
+      const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
+      const actionLink3 = await lawReg.take(ssids['belanghebbende'], actionLink2, '<<leraar trekt aanvraag subsidie voor studiekosten in>>', belanghebbendeFactresolver)
+
+      expect(actionLink3).to.be.a('string')
+
+      const lastAction = await core.get(actionLink3, ssids['bestuursorgaan'])
+
+      const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<leraar trekt aanvraag subsidie voor studiekosten in>>'))
+
+      expect(lastAction.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[leraar met aanvraag]': IdentityUtil.identityExpression(ssids['belanghebbende'].did),
+          '[aanvraag subsidie voor studiekosten]': actionLink2,
+          '[aanvraag]': actionLink2,
+          '[binnen twee maanden na het verstrekken van de subsidie]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink2
+      })
+    }).timeout(5000)
+
+    it('should perform an extended flow where minister refuses the request because they already got financing in the context of Lerarenbeurs', async () => {
+      const retrievedModel = await core.get(modelLink)
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
+            fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
+            fact === '[subsidie lerarenbeurs]' ||
+            fact === '[subsidie voor bacheloropleiding leraar]' ||
+            fact === '[leraar voldoet aan bevoegdheidseisen]' ||
+            fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
+            fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
+            fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
+            fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
+            fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
+            fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
+            fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
+            fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
+            fact === '[hoogte van de subsidie voor studiekosten]' ||
+            fact === '[subsidieverlening aan een leraar]' ||
+            fact === '[template voor aanvraagformulieren studiekosten]'
+        }
+        return false
+      }
+
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
+
+      const belanghebbendeFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[inleveren]' ||
+            fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]'
+        }
+        return false
+      }
+
+      const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
+      const actionLink3 = await lawReg.take(ssids['bestuursorgaan'], actionLink2, '<<minister verstrekt subsidie lerarenbeurs aan leraar>>', bestuursorgaanFactresolver)
+
+      const actionLink4 = await lawReg.take(ssids['bestuursorgaan'], actionLink3, '<<minister van OCW weigert subsidieverlening aan een leraar>>', bestuursorgaanFactresolver)
+
+      const lastAction = await core.get(actionLink4, ssids['bestuursorgaan'])
+
+      const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<minister van OCW weigert subsidieverlening aan een leraar>>'))
+
+      expect(lastAction.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
+          '[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]': actionLink3,
+          '[subsidieverlening aan een leraar]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink3
+      })
+    }).timeout(5000)
+
+    it('should be able to get available actions after fact created from another action', async () => {
+      const needSsid = await core.newSsid('ephemeral')
+      await core.allow(needSsid)
+
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[template voor aanvraagformulieren studiekosten]' || fact === '[minister van Onderwijs, Cultuur en Wetenschap]'
+        }
+        return false
+      }
+
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
+
+      const availableActs = await lawReg.getAvailableActs(actionLink, ssids['belanghebbende'], [], [])
+
+      expect(availableActs).to.deep.equal([])
+    }).timeout(5000)
+
+    it('should be able to get potential actions after fact created from another action', async () => {
+      const needSsid = await core.newSsid('ephemeral')
+      await core.allow(needSsid)
+
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[template voor aanvraagformulieren studiekosten]' || fact === '[minister van Onderwijs, Cultuur en Wetenschap]'
+        }
+        return false
+      }
+
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
+
+      const potentialActs = await lawReg.getPotentialActs(actionLink, ssids['belanghebbende'], [], [])
+
+      const potentialActNames = potentialActs.map((act) => act.act)
+      expect(potentialActNames).to.deep.equal([
+        '<<indienen verzoek een besluit te nemen>>',
+        '<<leraar vraagt subsidie voor studiekosten aan>>'
+      ])
+    }).timeout(5000)
   })
-  it('should be able to take an action where the object originates from another action - LERARENBEURS', async () => {
-    const retrievedModel = await core.get(modelLink)
-
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<indienen verzoek een besluit te nemen>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
-
-    const belanghebbendeFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[verzoek een besluit te nemen]'
-      }
-      return false
+  describe('with mutliple same type actors', () => {
+    const factFunctionSpec = {
+      '[persoon wiens belang rechtstreeks bij een besluit is betrokken]': ['belanghebbende1', 'belanghebbende2'],
+      '[degene die voldoet aan bevoegdheidseisen gesteld in]': ['belanghebbende1', 'belanghebbende2'],
+      '[artikel 3 van de Wet op het primair onderwijs]': ['belanghebbende1', 'belanghebbende2'],
+      '[artikel 3 van de Wet op de expertisecentra]': ['belanghebbende1', 'belanghebbende2'],
+      '[artikel XI van de Wet op de beroepen in het onderwijs]': ['belanghebbende1', 'belanghebbende2'],
+      '[artikel 3 van de Wet primair onderwijs BES]': ['belanghebbende1', 'belanghebbende2'],
+      '[is benoemd of tewerkgesteld zonder benoeming als bedoeld in artikel 33 van de Wet op het voortgezet onderwijs]': ['belanghebbende1', 'belanghebbende2'],
+      '[artikel 4.2.1. van de Wet educatie en beroepsonderwijs]': ['belanghebbende1', 'belanghebbende2'],
+      '[artikel 80 van de Wet voortgezet onderwijs BES]': ['belanghebbende1', 'belanghebbende2'],
+      '[artikel 4.2.1 van de Wet educatie beroepsonderwijs BES]': ['belanghebbende1', 'belanghebbende2'],
+      '[die lesgeeft in het hoger onderwijs]': ['belanghebbende1', 'belanghebbende2'],
+      '[orgaan]': 'bestuursorgaan',
+      '[rechtspersoon die krachtens publiekrecht is ingesteld]': 'bestuursorgaan',
+      '[met enig openbaar gezag bekleed]': 'bestuursorgaan',
+      '[artikel 1 van de Wet op het primair onderwijs]': 'bevoegdGezag',
+      '[artikel 1 van de Wet op de expertisecentra]': 'bevoegdGezag',
+      '[artikel 1 van de Wet op het voortgezet onderwijs]': 'bevoegdGezag',
+      '[artikel 1.1.1., onderdeel w, van de Wet educatie en beroepsonderwijs]': 'bevoegdGezag',
+      '[artikel 1 van de Wet primair onderwijs BES]': 'bevoegdGezag',
+      '[artikel 1 van de Wet voortgezet onderwijs BES]': 'bevoegdGezag',
+      '[artikel 1.1.1, van de Wet educatie en beroepsonderwijs BES]': 'bevoegdGezag',
+      '[instellingsbestuur bedoeld in artikel 1.1, onderdeel j, van de Wet op het hoger onderwijs en wetenschappelijk onderzoek]': 'bevoegdGezag',
+      '[minister van Onderwijs, Cultuur en Wetenschap]': 'bestuursorgaan',
+      '[persoon]': 'ANYONE'
     }
-
-    const actionLink = await lawReg.take(ssids['belanghebbende'], needLink, '<<indienen verzoek een besluit te nemen>>', belanghebbendeFactresolver)
-
-    const bestuursorgaanFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[persoon wiens belang rechtstreeks bij een besluit is betrokken]' ||
-          fact === '[aanvrager heeft de gelegenheid gehad de aanvraag aan te vullen]' ||
-          fact === '[de aanvraag is binnen de afgelopen 4 weken aangevuld]'
-      }
-      return false
+    const setupModel = async () => {
+      const util = new Util(lawReg)
+      return util.setupModel(lb, ['belanghebbende1', 'belanghebbende2', 'bestuursorgaan', 'bevoegdGezag'], factFunctionSpec)
     }
-
-    const secondActionLink = await lawReg.take(ssids['bestuursorgaan'], actionLink, '<<besluiten de aanvraag niet te behandelen>>', bestuursorgaanFactresolver)
-
-    expect(secondActionLink).to.be.a('string')
-
-    const action = await core.get(secondActionLink, ssids['bestuursorgaan'])
-
-    const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-      .filter(item => Object.keys(item).includes('<<besluiten de aanvraag niet te behandelen>>'))
-
-    expect(action.data).to.deep.equal({
-      'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_FACTS_SUPPLIED': {
-        '[aanvraag]': actionLink,
-        '[bestuursorgaan]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
-        '[aanvrager heeft de gelegenheid gehad de aanvraag aan te vullen]': true,
-        '[aanvrager heeft voldaan aan enig wettelijk voorschrift voor het in behandeling nemen van de aanvraag]': false,
-        '[de aanvraag is binnen de afgelopen 4 weken aangevuld]': true
-      },
-      'DISCIPL_FLINT_GLOBAL_CASE': needLink,
-      'DISCIPL_FLINT_PREVIOUS_CASE': actionLink
+    before(async () => {
+      ({ ssids, modelLink } = await setupModel())
     })
+    it('should perform an extended happy flow in the context of Lerarenbeurs', async () => {
+      const retrievedModel = await core.get(modelLink)
+      const needSsid = await core.newSsid('ephemeral')
 
-    const takenActs = await lawReg.getActions(secondActionLink, ssids['belanghebbende'])
-    expect(takenActs).to.deep.equal([{ 'act': '<<indienen verzoek een besluit te nemen>>', 'link': actionLink }, { 'act': '<<besluiten de aanvraag niet te behandelen>>', 'link': secondActionLink }])
-  }).timeout(5000)
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
 
-  it('should be able to determine available actions', async () => {
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<indienen verzoek een besluit te nemen>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
+            fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
+            fact === '[subsidie lerarenbeurs]' ||
+            fact === '[subsidie voor bacheloropleiding leraar]' ||
+            fact === '[leraar voldoet aan bevoegdheidseisen]' ||
+            fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
+            fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
+            fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
+            fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
+            fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
+            fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
+            fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
+            fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
+            fact === '[hoogte van de subsidie voor studiekosten]' ||
+            fact === '[template voor aanvraagformulieren studiekosten]'
+        }
+        return false
       }
-    })
 
-    const allowedActs = await lawReg.getAvailableActs(needLink, ssids['belanghebbende'], ['[verzoek een besluit te nemen]'], ['[bij wettelijk voorschrift is anders bepaald]'])
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
 
-    const allowedActNames = allowedActs.map((act) => act.act)
-
-    expect(allowedActNames).to.deep.equal(['<<indienen verzoek een besluit te nemen>>'])
-  }).timeout(10000)
-
-  it('should be able to determine available actions with nonfacts', async () => {
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<indienen verzoek een besluit te nemen>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
+      const belanghebbendeFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[inleveren]' ||
+            fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]'
+        }
+        return false
       }
-    })
 
-    const allowedActs = await lawReg.getAvailableActs(needLink, ssids['belanghebbende'], [], ['[verzoek een besluit te nemen]'])
+      const actionLink2 = await lawReg.take(ssids['belanghebbende1'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
+      const actionLink3 = await lawReg.take(ssids['bestuursorgaan'], actionLink2, '<<minister verstrekt subsidie lerarenbeurs aan leraar>>', bestuursorgaanFactresolver)
+      const actionLink4 = await lawReg.take(ssids['bestuursorgaan'], actionLink3, '<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>', bestuursorgaanFactresolver)
 
-    const allowedActNames = allowedActs.map((act) => act.act)
+      const thirdAction = await core.get(actionLink2, ssids['bestuursorgaan'])
 
-    expect(allowedActNames).to.deep.equal([])
-  }).timeout(10000)
+      const expectedThirdActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<leraar vraagt subsidie voor studiekosten aan>>'))
 
-  it('should be able to determine potentially available actions', async () => {
-    const { ssids, modelLink } = await setupModel()
+      const lastAction = await core.get(actionLink4, ssids['bestuursorgaan'])
 
-    const needSsid = await core.newSsid('ephemeral')
+      const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>'))
 
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<indienen verzoek een besluit te nemen>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
+      expect(thirdAction.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedThirdActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[leraar]': IdentityUtil.identityExpression(ssids['belanghebbende1'].did),
+          '[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]': actionLink,
+          '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]': true,
+          '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink
+      })
+
+      expect(lastAction.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
+          '[hoogte van de subsidie voor studiekosten]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink3
+      })
+    }).timeout(5000)
+
+    it('should perform an extended flow where teacher withdraws request in the context of Lerarenbeurs', async () => {
+      const retrievedModel = await core.get(modelLink)
+      const needSsid = await core.newSsid('ephemeral')
+
+      await core.allow(needSsid)
+      const needLink = await core.claim(needSsid, {
+        'need': {
+          'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
+          'DISCIPL_FLINT_MODEL_LINK': modelLink
+        }
+      })
+
+      const bestuursorgaanFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
+            fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
+            fact === '[subsidie lerarenbeurs]' ||
+            fact === '[subsidie voor bacheloropleiding leraar]' ||
+            fact === '[leraar voldoet aan bevoegdheidseisen]' ||
+            fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
+            fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
+            fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
+            fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
+            fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
+            fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
+            fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
+            fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
+            fact === '[hoogte van de subsidie voor studiekosten]' ||
+            fact === '[template voor aanvraagformulieren studiekosten]'
+        }
+        return false
       }
-    })
 
-    const allowedActs = await lawReg.getPotentialActs(needLink, ssids['belanghebbende'], [])
+      const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
 
-    const allowedActNames = allowedActs.map((act) => act.act)
-
-    expect(allowedActNames).to.deep.equal([
-      '<<indienen verzoek een besluit te nemen>>'
-    ])
-  }).timeout(10000)
-
-  it('should be able to determine potentially available actions with non-facts', async () => {
-    const { ssids, modelLink } = await setupModel()
-
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<indienen verzoek een besluit te nemen>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
+      const belanghebbendeFactresolver = (fact) => {
+        if (typeof fact === 'string') {
+          return fact === '[aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
+            fact === '[inleveren]' ||
+            fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]' ||
+            fact === '[binnen twee maanden na het verstrekken van de subsidie]'
+        }
+        return false
       }
-    })
 
-    const allowedActs = await lawReg.getPotentialActs(needLink, ssids['belanghebbende'], [], ['[verzoek een besluit te nemen]'])
+      const actionLink2 = await lawReg.take(ssids['belanghebbende1'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
+      const availableActs = (await lawReg.getAvailableActsWithResolver(actionLink2, ssids['belanghebbende2'], belanghebbendeFactresolver)).map((actInfo) => actInfo.act)
 
-    const allowedActNames = allowedActs.map((act) => act.act)
+      expect(availableActs).to.not.include('<<leraar trekt aanvraag subsidie voor studiekosten in>>', 'leraar2 should not be able to access aanvraag of leraar1')
+      const actionLink3 = await lawReg.take(ssids['belanghebbende1'], actionLink2, '<<leraar trekt aanvraag subsidie voor studiekosten in>>', belanghebbendeFactresolver)
 
-    expect(allowedActNames).to.deep.equal([])
-  }).timeout(10000)
+      const availableActs1 = (await lawReg.getAvailableActsWithResolver(actionLink2, ssids['belanghebbende2'], belanghebbendeFactresolver)).map((actInfo) => actInfo.act)
+      expect(availableActs1).to.not.include('<<leraar trekt aanvraag subsidie voor studiekosten in>>', 'aanvraag subsidie intrekken should destroy aanvraag')
 
-  it('should be able to determine potentially available actions from another perspective', async () => {
-    const needSsid = await core.newSsid('ephemeral')
+      expect(actionLink3).to.be.a('string')
 
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<indienen verzoek een besluit te nemen>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
+      const lastAction = await core.get(actionLink3, ssids['bestuursorgaan'])
 
-    const allowedActs = await lawReg.getPotentialActs(needLink, ssids['bestuursorgaan'], [])
+      const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
+        .filter(item => Object.keys(item).includes('<<leraar trekt aanvraag subsidie voor studiekosten in>>'))
 
-    const allowedActNames = allowedActs.map((act) => act.act)
-
-    expect(allowedActNames).to.deep.equal([
-      '<<vaststellen formulier voor verstrekken van gegevens>>',
-      '<<minister treft betalingsregeling voor het terugbetalen van de subsidie voor studiekosten>>',
-      '<<minister laat een of meer bepalingen van de subsidieregeling lerarenbeurs buiten toepassing>>',
-      '<<minister wijkt af van een of meer bepalingen van de subsidieregeling lerarenbeurs>>',
-      '<<minister van OCW verdeelt het beschikbare bedrag voor de subsidieregeling lerarenbeurs per doelgroep>>',
-      '<<minister van OCW verdeelt concreet het beschikbare budget in een studiejaar per soort onderwijs>>',
-      '<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>',
-      '<<minister van OCW berekent de hoogte van de subsidie voor studieverlof>>',
-      '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>',
-      '<<aanvraagformulieren verstrekken voor subsidie studieverlof op de website van de DUO>>'
-    ])
-  }).timeout(10000)
-
-  it('should perform multiple acts for a happy flow in the context of Lerarenbeurs', async () => {
-    const retrievedModel = await core.get(modelLink)
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<leraar vraagt subsidie voor studiekosten aan>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
-
-    const belanghebbendeFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[subsidie voor studiekosten]' ||
-          fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]'
-      }
-      return false
-    }
-
-    const bestuursorgaanFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[subsidie lerarenbeurs]' ||
-          fact === '[subsidie voor bacheloropleiding leraar]' ||
-          fact === '[leraar voldoet aan bevoegdheidseisen]' ||
-          fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
-          fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
-          fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
-          fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
-          fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
-          fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
-          fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
-          fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
-          fact === '[template voor aanvraagformulieren studiekosten]'
-      }
-      return false
-    }
-
-    const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
-
-    const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
-
-    const actionLink3 = await lawReg.take(ssids['bestuursorgaan'], actionLink2, '<<minister verstrekt subsidie lerarenbeurs aan leraar>>', bestuursorgaanFactresolver)
-
-    const action = await core.get(actionLink3, ssids['bestuursorgaan'])
-
-    const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-      .filter(item => Object.keys(item).includes('<<minister verstrekt subsidie lerarenbeurs aan leraar>>'))
-
-    expect(action.data).to.deep.equal({
-      'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_FACTS_SUPPLIED': {
-        '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
-        '[aanvraag]': actionLink2,
-        '[budget volledig benut]': false,
-        '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]': true,
-        '[leraar die ingeschreven staat in registerleraar.nl]': true,
-        '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]': true,
-        '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]': true,
-        '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]': true,
-        '[leraar is aangesteld als ambulant begeleider]': false,
-        '[leraar is aangesteld als intern begeleider]': false,
-        '[leraar is aangesteld als remedial teacher]': false,
-        '[leraar is aangesteld als zorgcoördinator]': false,
-        '[leraar ontvangt van de minister een tegemoetkoming in de studiekosten voor het volgen van de opleiding]': false,
-        '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]': true,
-        '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]': true,
-        '[subsidie lerarenbeurs]': true,
-        '[subsidie voor bacheloropleiding leraar]': true,
-        '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]': true
-      },
-      'DISCIPL_FLINT_GLOBAL_CASE': needLink,
-      'DISCIPL_FLINT_PREVIOUS_CASE': actionLink2
-    })
-  }).timeout(5000)
-
-  it('should perform an extended happy flow in the context of Lerarenbeurs', async () => {
-    const retrievedModel = await core.get(modelLink)
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
-
-    const bestuursorgaanFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
-          fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
-          fact === '[subsidie lerarenbeurs]' ||
-          fact === '[subsidie voor bacheloropleiding leraar]' ||
-          fact === '[leraar voldoet aan bevoegdheidseisen]' ||
-          fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
-          fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
-          fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
-          fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
-          fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
-          fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
-          fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
-          fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
-          fact === '[hoogte van de subsidie voor studiekosten]' ||
-          fact === '[template voor aanvraagformulieren studiekosten]'
-      }
-      return false
-    }
-
-    const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
-
-    const belanghebbendeFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[inleveren]' ||
-          fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]'
-      }
-      return false
-    }
-
-    const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
-    const actionLink3 = await lawReg.take(ssids['bestuursorgaan'], actionLink2, '<<minister verstrekt subsidie lerarenbeurs aan leraar>>', bestuursorgaanFactresolver)
-    const actionLink4 = await lawReg.take(ssids['bestuursorgaan'], actionLink3, '<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>', bestuursorgaanFactresolver)
-
-    const thirdAction = await core.get(actionLink2, ssids['bestuursorgaan'])
-
-    const expectedThirdActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-      .filter(item => Object.keys(item).includes('<<leraar vraagt subsidie voor studiekosten aan>>'))
-
-    const lastAction = await core.get(actionLink4, ssids['bestuursorgaan'])
-
-    const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-      .filter(item => Object.keys(item).includes('<<minister van OCW berekent de hoogte van de subsidie voor studiekosten>>'))
-
-    expect(thirdAction.data).to.deep.equal({
-      'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedThirdActLink[0])[0],
-      'DISCIPL_FLINT_FACTS_SUPPLIED': {
-        '[leraar]': IdentityUtil.identityExpression(ssids['belanghebbende'].did),
-        '[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]': actionLink,
-        '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]': true,
-        '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]': true
-      },
-      'DISCIPL_FLINT_GLOBAL_CASE': needLink,
-      'DISCIPL_FLINT_PREVIOUS_CASE': actionLink
-    })
-
-    expect(lastAction.data).to.deep.equal({
-      'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_FACTS_SUPPLIED': {
-        '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
-        '[hoogte van de subsidie voor studiekosten]': true
-      },
-      'DISCIPL_FLINT_GLOBAL_CASE': needLink,
-      'DISCIPL_FLINT_PREVIOUS_CASE': actionLink3
-    })
-  }).timeout(5000)
-
-  it('should perform an extended flow where teacher withdraws request in the context of Lerarenbeurs', async () => {
-    const retrievedModel = await core.get(modelLink)
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
-
-    const bestuursorgaanFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
-          fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
-          fact === '[subsidie lerarenbeurs]' ||
-          fact === '[subsidie voor bacheloropleiding leraar]' ||
-          fact === '[leraar voldoet aan bevoegdheidseisen]' ||
-          fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
-          fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
-          fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
-          fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
-          fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
-          fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
-          fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
-          fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
-          fact === '[hoogte van de subsidie voor studiekosten]' ||
-          fact === '[template voor aanvraagformulieren studiekosten]'
-      }
-      return false
-    }
-
-    const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
-
-    const belanghebbendeFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[inleveren]' ||
-          fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]' ||
-          fact === '[binnen twee maanden na het verstrekken van de subsidie]'
-      }
-      return false
-    }
-
-    const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
-    const actionLink3 = await lawReg.take(ssids['belanghebbende'], actionLink2, '<<leraar trekt aanvraag subsidie voor studiekosten in>>', belanghebbendeFactresolver)
-
-    expect(actionLink3).to.be.a('string')
-
-    const lastAction = await core.get(actionLink3, ssids['bestuursorgaan'])
-
-    const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-      .filter(item => Object.keys(item).includes('<<leraar trekt aanvraag subsidie voor studiekosten in>>'))
-
-    expect(lastAction.data).to.deep.equal({
-      'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_FACTS_SUPPLIED': {
-        '[leraar]': IdentityUtil.identityExpression(ssids['belanghebbende'].did),
-        '[aanvraag subsidie voor studiekosten]': actionLink2,
-        '[binnen twee maanden na het verstrekken van de subsidie]': true
-      },
-      'DISCIPL_FLINT_GLOBAL_CASE': needLink,
-      'DISCIPL_FLINT_PREVIOUS_CASE': actionLink2
-    })
-  }).timeout(5000)
-
-  it('should perform an extended flow where minister refuses the request because they already got financing in the context of Lerarenbeurs', async () => {
-    const retrievedModel = await core.get(modelLink)
-    const needSsid = await core.newSsid('ephemeral')
-
-    await core.allow(needSsid)
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
-
-    const bestuursorgaanFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[template voor aanvraagformulieren op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[schriftelijke beslissing van een bestuursorgaan]' ||
-          fact === '[beslissing inhoudende een publiekrechtelijke rechtshandeling]' ||
-          fact === '[subsidie lerarenbeurs]' ||
-          fact === '[subsidie voor bacheloropleiding leraar]' ||
-          fact === '[leraar voldoet aan bevoegdheidseisen]' ||
-          fact === '[leraar werkt bij een of meer bekostigde onderwijsinstellingen]' ||
-          fact === '[leraar die bij aanvang van het studiejaar waarvoor de subsidie bestemd de graad Bachelor mag voeren]' ||
-          fact === '[leraar die op het moment van de subsidieaanvraag in dienst is bij een werkgever]' ||
-          fact === '[leraar die voor minimaal twintig procent van zijn werktijd is belast met lesgebonden taken]' ||
-          fact === '[leraar die pedagogisch-didactisch verantwoordelijk is voor het onderwijs]' ||
-          fact === '[leraar die ingeschreven staat in registerleraar.nl]' ||
-          fact === '[subsidie wordt verstrekt voor één studiejaar en voor één opleiding]' ||
-          fact === '[minister verdeelt het beschikbare bedrag per doelgroep over de aanvragen]' ||
-          fact === '[hoogte van de subsidie voor studiekosten]' ||
-          fact === '[subsidieverlening aan een leraar]' ||
-          fact === '[template voor aanvraagformulieren studiekosten]'
-      }
-      return false
-    }
-
-    const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
-
-    const belanghebbendeFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[ingevuld aanvraagformulier studiekosten op de website van de Dienst Uitvoering Onderwijs]' ||
-          fact === '[inleveren]' ||
-          fact === '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]'
-      }
-      return false
-    }
-
-    const actionLink2 = await lawReg.take(ssids['belanghebbende'], actionLink, '<<leraar vraagt subsidie voor studiekosten aan>>', belanghebbendeFactresolver)
-    const actionLink3 = await lawReg.take(ssids['bestuursorgaan'], actionLink2, '<<minister verstrekt subsidie lerarenbeurs aan leraar>>', bestuursorgaanFactresolver)
-
-    const actionLink4 = await lawReg.take(ssids['bestuursorgaan'], actionLink3, '<<minister van OCW weigert subsidieverlening aan een leraar>>', bestuursorgaanFactresolver)
-
-    const lastAction = await core.get(actionLink4, ssids['bestuursorgaan'])
-
-    const expectedActLink = retrievedModel.data['DISCIPL_FLINT_MODEL'].acts
-      .filter(item => Object.keys(item).includes('<<minister van OCW weigert subsidieverlening aan een leraar>>'))
-
-    expect(lastAction.data).to.deep.equal({
-      'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
-      'DISCIPL_FLINT_FACTS_SUPPLIED': {
-        '[minister van Onderwijs, Cultuur en Wetenschap]': IdentityUtil.identityExpression(ssids['bestuursorgaan'].did),
-        '[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]': actionLink3,
-        '[subsidieverlening aan een leraar]': true
-      },
-      'DISCIPL_FLINT_GLOBAL_CASE': needLink,
-      'DISCIPL_FLINT_PREVIOUS_CASE': actionLink3
-    })
-  }).timeout(5000)
-
-  it('should be able to get available actions after fact created from another action', async () => {
-    const needSsid = await core.newSsid('ephemeral')
-    await core.allow(needSsid)
-
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
-
-    const bestuursorgaanFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[template voor aanvraagformulieren studiekosten]' || fact === '[minister van Onderwijs, Cultuur en Wetenschap]'
-      }
-      return false
-    }
-
-    const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
-
-    const availableActs = await lawReg.getAvailableActs(actionLink, ssids['belanghebbende'], [], [])
-
-    expect(availableActs).to.deep.equal([])
-  }).timeout(5000)
-
-  it('should be able to get potential actions after fact created from another action', async () => {
-    const needSsid = await core.newSsid('ephemeral')
-    await core.allow(needSsid)
-
-    const needLink = await core.claim(needSsid, {
-      'need': {
-        'act': '<<aanvraagformulieren lerarenbeurs verstrekken>>',
-        'DISCIPL_FLINT_MODEL_LINK': modelLink
-      }
-    })
-
-    const bestuursorgaanFactresolver = (fact) => {
-      if (typeof fact === 'string') {
-        return fact === '[template voor aanvraagformulieren studiekosten]' || fact === '[minister van Onderwijs, Cultuur en Wetenschap]'
-      }
-      return false
-    }
-
-    const actionLink = await lawReg.take(ssids['bestuursorgaan'], needLink, '<<aanvraagformulieren verstrekken voor subsidie studiekosten op de website van de DUO>>', bestuursorgaanFactresolver)
-
-    const potentialActs = await lawReg.getPotentialActs(actionLink, ssids['belanghebbende'], [], [])
-
-    const potentialActNames = potentialActs.map((act) => act.act)
-    expect(potentialActNames).to.deep.equal([
-      '<<indienen verzoek een besluit te nemen>>',
-      '<<leraar vraagt subsidie voor studiekosten aan>>'
-    ])
-  }).timeout(5000)
+      expect(lastAction.data).to.deep.equal({
+        'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+        'DISCIPL_FLINT_FACTS_SUPPLIED': {
+          '[leraar met aanvraag]': IdentityUtil.identityExpression(ssids['belanghebbende1'].did),
+          '[aanvraag subsidie voor studiekosten]': actionLink2,
+          '[aanvraag]': actionLink2,
+          '[binnen twee maanden na het verstrekken van de subsidie]': true
+        },
+        'DISCIPL_FLINT_GLOBAL_CASE': needLink,
+        'DISCIPL_FLINT_PREVIOUS_CASE': actionLink2
+      })
+    }).timeout(5000)
+  })
 })

--- a/test/lerarenbeurs-scenarios.spec.js
+++ b/test/lerarenbeurs-scenarios.spec.js
@@ -92,6 +92,7 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(action.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
         '[aanvraag]': actionLink,
         '[aanvrager heeft de gelegenheid gehad de aanvraag aan te vullen]': true,
@@ -265,6 +266,7 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(action.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
         '[aanvraag]': actionLink2,
         '[budget volledig benut]': false,
@@ -351,6 +353,7 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(thirdAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedThirdActLink[0])[0],
+      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['belanghebbende'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
         '[aanvraagformulieren studiekosten op de website van de Dienst Uitvoering Onderwijs]': actionLink,
         '[indienen 1 april tot en met 30 juni, voorafgaand aan het studiejaar waarvoor subsidie wordt aangevraagd]': true,
@@ -362,6 +365,7 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(lastAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
         '[hoogte van de subsidie voor studiekosten]': true
       },
@@ -429,6 +433,7 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(lastAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['belanghebbende'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
         '[aanvraag subsidie voor studiekosten]': actionLink2,
         '[binnen twee maanden na het verstrekken van de subsidie]': true
@@ -496,6 +501,7 @@ describe('discipl-law-reg in scenarios with lerarenbeurs', () => {
 
     expect(lastAction.data).to.deep.equal({
       'DISCIPL_FLINT_ACT_TAKEN': Object.values(expectedActLink[0])[0],
+      'DISCIPL_FLINT_ACT_TAKEN_BY': ssids['bestuursorgaan'].did,
       'DISCIPL_FLINT_FACTS_SUPPLIED': {
         '[besluit tot verlenen subsidie voor studiekosten van een leraar in verband met het volgen van een opleiding]': actionLink3,
         '[subsidieverlening aan een leraar]': true


### PR DESCRIPTION
This PR adds support for the `PROJECTION`, an additional expression that can be used together with the `CREATE` expression.

The  expression consists out of the properties `context` and `fact`. The `context` property is an array to allow the usage of nested `CREATE` expressions.
```json
{
    "expression": "PROJECTION",
    "context": [
        "[aanvraag]"
    ],
    "fact": "[bedrag]"
}
```

Model example:
```json
{
    "acts": [
        {
            "act": "<<subsidie aanvragen>>",
            "actor": "[burger]",
            "recipient": "[ambtenaar]",
            "object": "[verzoek]",
            "preconditions": {
                "expression": "AND",
                "operands": [
                    "[bedrag]"
                ]
            },
            "create": [
                "[aanvraag]"
            ]
        },
        {
            "act": "<<subsidie aanvraag toekennen>>",
            "actor": "[ambtenaar]",
            "object": "[aanvraag]",
            "preconditions": {
                "expression": "LESS_THEN",
                "operands": [
                    {
                        "expression": "PROJECTION",
                        "context": [
                            "[aanvraag]"
                        ],
                        "fact": "[bedrag]"
                    },
                    {
                        "expression": "LITERAL",
                        "operand": 500
                    }
                ]
            },
            "recipient": "[burger]"
        }
    ],
    "facts": [
        {
            "fact": "[aanvraag]",
            "function": {
                "expression": "CREATE",
                "operands": [
                    "[bedrag]"
                ]
            }
        }
    ],
    "duties": []
}
```